### PR TITLE
Add notebook for estimating the number of gates in benchmark circuits

### DIFF
--- a/qem-on-hardware/count_number_of_gates.ipynb
+++ b/qem-on-hardware/count_number_of_gates.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d97713d9",
+   "id": "b50d60bb",
    "metadata": {},
    "source": [
     "# Counting gates in benchmark circuits"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b62ba675",
+   "id": "5e78a952",
    "metadata": {},
    "source": [
     "**Description**\n",
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91eef3e0",
+   "id": "3c25c034",
    "metadata": {},
    "source": [
     "## Setup"
@@ -29,87 +29,20 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "9a9db726",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 1;\n",
-       "                var nbb_unformatted_code = \"%load_ext nb_black\";\n",
-       "                var nbb_formatted_code = \"%load_ext nb_black\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%load_ext nb_black"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "cdac8249",
+   "id": "52096826",
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/andrea/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:20: DeprecationWarning: The qiskit.ignis package is deprecated and has been supersceded by the qiskit-experiments project. Refer to the migration guide: https://github.com/Qiskit/qiskit-ignis#migration-guide on how to migrate to the new project.\n"
+      "/home/andrea/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:16: DeprecationWarning: The qiskit.ignis package is deprecated and has been supersceded by the qiskit-experiments project. Refer to the migration guide: https://github.com/Qiskit/qiskit-ignis#migration-guide on how to migrate to the new project.\n",
+      "  app.launch_new_instance()\n"
      ]
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 2;\n",
-       "                var nbb_unformatted_code = \"import os\\nimport functools\\nimport time\\nfrom typing import Dict, List, Tuple, Union\\n\\n# Plotting imports.\\nimport matplotlib.pyplot as plt\\n\\n%matplotlib inline\\nplt.rcParams.update({\\\"font.family\\\": \\\"serif\\\", \\\"font.size\\\": 12})\\n\\n# Third-party imports.\\nimport cirq\\nimport networkx as nx\\nimport numpy as np\\nimport pandas as pd\\n\\n# Qiskit imports.\\nimport qiskit\\nimport qiskit.ignis.verification.randomized_benchmarking as rb\\nfrom qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\\nfrom qiskit.circuit import Gate\\n\\n# Mitiq imports.\\nfrom mitiq.interface import convert_to_mitiq, convert_from_mitiq\\nfrom mitiq import benchmarks, pec, zne\\n\\n# For hardware device offerings.\\nfrom braket.aws import AwsDevice\\nfrom braket.devices import LocalSimulator\\nfrom braket.circuits import Circuit, gates, Noise\";\n",
-       "                var nbb_formatted_code = \"import os\\nimport functools\\nimport time\\nfrom typing import Dict, List, Tuple, Union\\n\\n# Plotting imports.\\nimport matplotlib.pyplot as plt\\n\\n%matplotlib inline\\nplt.rcParams.update({\\\"font.family\\\": \\\"serif\\\", \\\"font.size\\\": 12})\\n\\n# Third-party imports.\\nimport cirq\\nimport networkx as nx\\nimport numpy as np\\nimport pandas as pd\\n\\n# Qiskit imports.\\nimport qiskit\\nimport qiskit.ignis.verification.randomized_benchmarking as rb\\nfrom qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\\nfrom qiskit.circuit import Gate\\n\\n# Mitiq imports.\\nfrom mitiq.interface import convert_to_mitiq, convert_from_mitiq\\nfrom mitiq import benchmarks, pec, zne\\n\\n# For hardware device offerings.\\nfrom braket.aws import AwsDevice\\nfrom braket.devices import LocalSimulator\\nfrom braket.circuits import Circuit, gates, Noise\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
-    "import os\n",
-    "import functools\n",
-    "import time\n",
-    "from typing import Dict, List, Tuple, Union\n",
+    "from typing import Tuple, Union\n",
     "\n",
     "# Plotting imports.\n",
     "import matplotlib.pyplot as plt\n",
@@ -121,27 +54,22 @@
     "import cirq\n",
     "import networkx as nx\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
     "\n",
     "# Qiskit imports.\n",
     "import qiskit\n",
     "import qiskit.ignis.verification.randomized_benchmarking as rb\n",
     "from qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\n",
-    "from qiskit.circuit import Gate\n",
     "\n",
     "# Mitiq imports.\n",
     "from mitiq.interface import convert_to_mitiq, convert_from_mitiq\n",
-    "from mitiq import benchmarks, pec, zne\n",
+    "from mitiq import benchmarks\n",
     "\n",
-    "# For hardware device offerings.\n",
-    "from braket.aws import AwsDevice\n",
-    "from braket.devices import LocalSimulator\n",
-    "from braket.circuits import Circuit, gates, Noise"
+    "from braket.circuits import Circuit, gates"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "49929d1d",
+   "id": "4f30f983",
    "metadata": {},
    "source": [
     "### Parameters"
@@ -149,8 +77,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "e8b12ab9",
+   "execution_count": 2,
+   "id": "7d266d29",
    "metadata": {},
    "outputs": [
     {
@@ -160,33 +88,6 @@
       "Qubit indeces: [0, 1, 2]\n",
       "RB pattern: [[0, 1], [2]]\n"
      ]
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 3;\n",
-       "                var nbb_unformatted_code = \"# Benchmark circuit type. Supported types are \\\"rb\\\" and \\\"mirror\\\".\\ncircuit_type: str = \\\"rb\\\"  \\n\\n# Qubits to use on the experiment. \\nnum_qubits = 3\\n\\nqubits = [j for j in range(num_qubits)]\\n\\n# Split qubits into 2-qubit pairs (assuming a chain connectivity). \\nrb_pattern = [[qa, qb] for qa, qb in zip(qubits[0:-1:2], qubits[1::2])]\\nif len(qubits) % 2 == 1:\\n    # For an odd number of qubits, append final individual qubit to the RB pattern.\\n    rb_pattern.append([qubits[-1]])\\nprint(\\\"Qubit indeces:\\\", qubits)\\nprint(\\\"RB pattern:\\\", rb_pattern)\";\n",
-       "                var nbb_formatted_code = \"# Benchmark circuit type. Supported types are \\\"rb\\\" and \\\"mirror\\\".\\ncircuit_type: str = \\\"rb\\\"\\n\\n# Qubits to use on the experiment.\\nnum_qubits = 3\\n\\nqubits = [j for j in range(num_qubits)]\\n\\n# Split qubits into 2-qubit pairs (assuming a chain connectivity).\\nrb_pattern = [[qa, qb] for qa, qb in zip(qubits[0:-1:2], qubits[1::2])]\\nif len(qubits) % 2 == 1:\\n    # For an odd number of qubits, append final individual qubit to the RB pattern.\\n    rb_pattern.append([qubits[-1]])\\nprint(\\\"Qubit indeces:\\\", qubits)\\nprint(\\\"RB pattern:\\\", rb_pattern)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -209,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c57056f",
+   "id": "873f0ece",
    "metadata": {},
    "source": [
     "### Hardware parameters"
@@ -217,38 +118,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "36ebb12c",
+   "execution_count": 3,
+   "id": "b9b78c0e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 4;\n",
-       "                var nbb_unformatted_code = \"# Hardware backend device type. Supported types are \\\"rigetti\\\", \\\"ibmq\\\", and \\\"ionq\\\".\\nhardware_type: str = \\\"ibmq\\\"\";\n",
-       "                var nbb_formatted_code = \"# Hardware backend device type. Supported types are \\\"rigetti\\\", \\\"ibmq\\\", and \\\"ionq\\\".\\nhardware_type: str = \\\"ibmq\\\"\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Hardware backend device type. Supported types are \"rigetti\", \"ibmq\", and \"ionq\".\n",
     "hardware_type: str = \"ibmq\""
@@ -256,7 +129,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8f3f9a8",
+   "id": "512a8b81",
    "metadata": {},
    "source": [
     "### Hardware architecture\n",
@@ -266,8 +139,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "d0ecec92",
+   "execution_count": 4,
+   "id": "c57f3754",
    "metadata": {},
    "outputs": [
     {
@@ -276,33 +149,6 @@
      "text": [
       "Computer connectivity (used only for mirror circuits): [(0, 1), (1, 0), (1, 2), (2, 1)]\n"
      ]
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 5;\n",
-       "                var nbb_unformatted_code = \"computer = nx.Graph()\\n\\n# Assume chain-like connectivity\\ncomputer.add_edges_from([(qa, qb) for qa, qb in zip(qubits[:-1], qubits[1:])])\\n\\n# Add reversed edges to computer graph.\\n# This is important to represent CNOT gates with target and control reversed.\\ncomputer = nx.to_directed(computer)\\n\\n\\n# Check if RB-pattern is consistent with device topology.\\nfor edge in rb_pattern:\\n    if len(edge) == 2:\\n        if edge not in computer.edges:\\n            raise ValueError(\\n                \\\"The option rb_pattern is not consistent with the device topology.\\\"\\n            )\\n\\nprint(\\\"Computer connectivity (used only for mirror circuits):\\\", computer.edges)\";\n",
-       "                var nbb_formatted_code = \"computer = nx.Graph()\\n\\n# Assume chain-like connectivity\\ncomputer.add_edges_from([(qa, qb) for qa, qb in zip(qubits[:-1], qubits[1:])])\\n\\n# Add reversed edges to computer graph.\\n# This is important to represent CNOT gates with target and control reversed.\\ncomputer = nx.to_directed(computer)\\n\\n\\n# Check if RB-pattern is consistent with device topology.\\nfor edge in rb_pattern:\\n    if len(edge) == 2:\\n        if edge not in computer.edges:\\n            raise ValueError(\\n                \\\"The option rb_pattern is not consistent with the device topology.\\\"\\n            )\\n\\nprint(\\\"Computer connectivity (used only for mirror circuits):\\\", computer.edges)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -329,7 +175,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59a7f99c",
+   "id": "97e5b505",
    "metadata": {},
    "source": [
     "### Benchmark circuit"
@@ -337,38 +183,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "3210e6fd",
+   "execution_count": 5,
+   "id": "ee1bb551",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 6;\n",
-       "                var nbb_unformatted_code = \"def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\\n    \\\"\\\"\\\"Extract qubit number assuming \\\"_\\\" is used as a word separator.\\\"\\\"\\\"\\n    digits = [int(s) for s in named_qubit.name.split(\\\"_\\\") if s.isdigit()]\\n    if len(digits) == 1:\\n        return cirq.LineQubit(digits[0])\\n    else:\\n        raise RuntimeError(\\\"Failed to identify qubit number.\\\")\";\n",
-       "                var nbb_formatted_code = \"def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\\n    \\\"\\\"\\\"Extract qubit number assuming \\\"_\\\" is used as a word separator.\\\"\\\"\\\"\\n    digits = [int(s) for s in named_qubit.name.split(\\\"_\\\") if s.isdigit()]\\n    if len(digits) == 1:\\n        return cirq.LineQubit(digits[0])\\n    else:\\n        raise RuntimeError(\\\"Failed to identify qubit number.\\\")\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\n",
     "    \"\"\"Extract qubit number assuming \"_\" is used as a word separator.\"\"\"\n",
@@ -381,38 +199,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "b2140186",
+   "execution_count": 6,
+   "id": "6c3f4f3e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 7;\n",
-       "                var nbb_unformatted_code = \"def get_rb_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n    circuit = rb.randomized_benchmarking_seq(\\n        length_vector=[depth],\\n        rb_pattern=rb_pattern,\\n        group_gates=\\\"0\\\",\\n        rand_seed=seed,\\n    )[0][0][0]\\n\\n    # Remove barriers and measurements.\\n    circuit = RemoveFinalMeasurements()(RemoveBarriers()(circuit))\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        # Qiskit --> Cirq.\\n        cirq_circuit, _ = convert_to_mitiq(circuit)\\n        circuit_with_linequbits = cirq_circuit.transform_qubits(\\n            named_qubit_to_line_qubit\\n        )\\n\\n        # Cirq --> Braket.\\n        return convert_from_mitiq(circuit_with_linequbits, \\\"braket\\\"), \\\"0\\\" * len(qubits)\\n\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Hack: Remove classical register and rename qubit register.\\n        return convert_from_mitiq(convert_to_mitiq(circuit)[0], \\\"qiskit\\\"), \\\"0\\\" * len(\\n            qubits\\n        )\\n\\n\\ndef get_mirror_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n\\n    return_type = (\\n        \\\"braket\\\" if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\" else \\\"qiskit\\\"\\n    )\\n    circuit, correct_bitstring = benchmarks.generate_mirror_circuit(\\n        nlayers=depth,\\n        two_qubit_gate_prob=1.0,\\n        connectivity_graph=computer,\\n        two_qubit_gate_name=\\\"CNOT\\\",\\n        seed=seed,\\n        return_type=return_type,\\n    )\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return circuit, correct_bitstring\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Reversed because Qiskit is wrong endian.\\n        return circuit, \\\"\\\".join(map(str, correct_bitstring[::-1]))\";\n",
-       "                var nbb_formatted_code = \"def get_rb_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n    circuit = rb.randomized_benchmarking_seq(\\n        length_vector=[depth],\\n        rb_pattern=rb_pattern,\\n        group_gates=\\\"0\\\",\\n        rand_seed=seed,\\n    )[0][0][0]\\n\\n    # Remove barriers and measurements.\\n    circuit = RemoveFinalMeasurements()(RemoveBarriers()(circuit))\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        # Qiskit --> Cirq.\\n        cirq_circuit, _ = convert_to_mitiq(circuit)\\n        circuit_with_linequbits = cirq_circuit.transform_qubits(\\n            named_qubit_to_line_qubit\\n        )\\n\\n        # Cirq --> Braket.\\n        return convert_from_mitiq(circuit_with_linequbits, \\\"braket\\\"), \\\"0\\\" * len(qubits)\\n\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Hack: Remove classical register and rename qubit register.\\n        return convert_from_mitiq(convert_to_mitiq(circuit)[0], \\\"qiskit\\\"), \\\"0\\\" * len(\\n            qubits\\n        )\\n\\n\\ndef get_mirror_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n\\n    return_type = (\\n        \\\"braket\\\" if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\" else \\\"qiskit\\\"\\n    )\\n    circuit, correct_bitstring = benchmarks.generate_mirror_circuit(\\n        nlayers=depth,\\n        two_qubit_gate_prob=1.0,\\n        connectivity_graph=computer,\\n        two_qubit_gate_name=\\\"CNOT\\\",\\n        seed=seed,\\n        return_type=return_type,\\n    )\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return circuit, correct_bitstring\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Reversed because Qiskit is wrong endian.\\n        return circuit, \\\"\\\".join(map(str, correct_bitstring[::-1]))\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def get_rb_circuit(\n",
     "    depth: int, seed: int\n",
@@ -469,7 +259,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88f1838e",
+   "id": "d80eb68e",
    "metadata": {},
    "source": [
     "### Gateset compilation functions"
@@ -477,38 +267,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "552cb84f",
+   "execution_count": 7,
+   "id": "a8cde868",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 8;\n",
-       "                var nbb_unformatted_code = \"def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\\n    \\\"\\\"\\\"Compiles AWS gates to Rigetti gateset. Taken from:\\n    https://mitiq.readthedocs.io/en/stable/examples/braket_mirror_circuit.html\\\"\\\"\\\"\\n    compiled = Circuit()\\n\\n    for instr in circuit.instructions:\\n        if isinstance(instr.operator, gates.Vi):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.V):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Ry):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-instr.operator.angle), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Y):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.X):\\n            compiled.add_instruction(gates.Instruction(gates.Rx(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.Z):\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.S):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Si):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.H):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.CNot):\\n            # First Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n\\n            # Controlled-Z\\n            compiled.add_instruction(gates.Instruction(gates.CZ(), instr.target))\\n\\n            # Second Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n        else:\\n            compiled.add_instruction(instr)\\n\\n    return compiled\";\n",
-       "                var nbb_formatted_code = \"def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\\n    \\\"\\\"\\\"Compiles AWS gates to Rigetti gateset. Taken from:\\n    https://mitiq.readthedocs.io/en/stable/examples/braket_mirror_circuit.html\\\"\\\"\\\"\\n    compiled = Circuit()\\n\\n    for instr in circuit.instructions:\\n        if isinstance(instr.operator, gates.Vi):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.V):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Ry):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-instr.operator.angle), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Y):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.X):\\n            compiled.add_instruction(gates.Instruction(gates.Rx(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.Z):\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.S):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Si):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.H):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.CNot):\\n            # First Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n\\n            # Controlled-Z\\n            compiled.add_instruction(gates.Instruction(gates.CZ(), instr.target))\\n\\n            # Second Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n        else:\\n            compiled.add_instruction(instr)\\n\\n    return compiled\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\n",
     "    \"\"\"Compiles AWS gates to Rigetti gateset. Taken from:\n",
@@ -597,7 +359,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8d22b993",
+   "id": "6bd59f90",
    "metadata": {},
    "source": [
     "### CNOT count utility functions"
@@ -605,38 +367,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "120631e4",
+   "execution_count": 8,
+   "id": "e182fbfa",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 9;\n",
-       "                var nbb_unformatted_code = \"def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    \\\"\\\"\\\"Determine number of two-qubit gates in a given `Circuit` object.\\\"\\\"\\\"\\n\\n    # Count CNOT gates for `cirq`-type circuit objects:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        num_cnots: int = 0\\n        for instruction in circuit.instructions:\\n            if isinstance(instruction.operator, gates.CNot) or isinstance(\\n                instruction.operator, gates.CZ\\n            ):\\n                num_cnots += 1\\n        return num_cnots\\n\\n    # Count CNOT gates for `qiskit`-type circuit objects:\\n    elif hardware_type == \\\"ibmq\\\":\\n        return circuit.count_ops().get(\\\"cx\\\")\\n\\n\\ndef get_oneq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return len(circuit.instructions) - get_num_twoq_count(circuit)\\n    elif hardware_type == \\\"ibmq\\\":\\n        return len(circuit) - get_num_twoq_count(circuit)\";\n",
-       "                var nbb_formatted_code = \"def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    \\\"\\\"\\\"Determine number of two-qubit gates in a given `Circuit` object.\\\"\\\"\\\"\\n\\n    # Count CNOT gates for `cirq`-type circuit objects:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        num_cnots: int = 0\\n        for instruction in circuit.instructions:\\n            if isinstance(instruction.operator, gates.CNot) or isinstance(\\n                instruction.operator, gates.CZ\\n            ):\\n                num_cnots += 1\\n        return num_cnots\\n\\n    # Count CNOT gates for `qiskit`-type circuit objects:\\n    elif hardware_type == \\\"ibmq\\\":\\n        return circuit.count_ops().get(\\\"cx\\\")\\n\\n\\ndef get_oneq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return len(circuit.instructions) - get_num_twoq_count(circuit)\\n    elif hardware_type == \\\"ibmq\\\":\\n        return len(circuit) - get_num_twoq_count(circuit)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\n",
     "    \"\"\"Determine number of two-qubit gates in a given `Circuit` object.\"\"\"\n",
@@ -665,7 +399,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7105282",
+   "id": "6378d8df",
    "metadata": {},
    "source": [
     "## Analyze the number of gates in RB circuits and in mirror circuits"
@@ -673,38 +407,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "8db26c58",
+   "execution_count": 9,
+   "id": "3399b013",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 10;\n",
-       "                var nbb_unformatted_code = \"def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\\n    \\\"\\\"\\\"Analyze the number of two-qubit and single-qubit gates.\\\"\\\"\\\"\\n\\n    depths = [1, 3, 5, 7, 9, 12]\\n\\n    num_twoq_gates = np.zeros(len(depths))\\n    num_oneq_gates = np.zeros(len(depths))\\n    for trial in range(num_trials):  # Average over different seeds\\n        num_twoq_gates_trial = []\\n        num_oneq_gates_trial = []\\n\\n        for depth in depths:\\n            if circuit_type_to_analyze == \\\"rb\\\":\\n                circuit, _ = get_rb_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n            elif circuit_type_to_analyze == \\\"mirror\\\":\\n                circuit, _ = get_mirror_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n\\n            # Compile to native gate set\\n            if hardware_type == \\\"rigetti\\\":\\n                circuit = compile_to_rigetti_gateset(circuit)\\n\\n            num_twoq_gates_trial.append(get_num_twoq_count(circuit))\\n            num_oneq_gates_trial.append(get_oneq_count(circuit))\\n        num_twoq_gates += np.array(num_twoq_gates_trial)\\n        num_oneq_gates += np.array(num_oneq_gates_trial)\\n\\n    num_twoq_gates /= num_trials\\n    num_oneq_gates /= num_trials\\n\\n    twoq_params = np.polyfit(depths, num_twoq_gates, 1)\\n    twoq_curve = np.poly1d(twoq_params)\\n\\n    oneq_params = np.polyfit(depths, num_oneq_gates, 1)\\n    oneq_curve = np.poly1d(oneq_params)\\n\\n    print(\\\"depth\\\\tnum. twoq\\\\tnum oneq\\\")\\n    print(\\\"-----------------------------------\\\")\\n\\n    for d, twoq, oneq in zip(depths, num_twoq_gates, num_oneq_gates):\\n        print(f\\\"{d}\\\\t{twoq}\\\\t\\\\t{oneq}\\\")\\n\\n    plt.ylabel(\\\"Number of two-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_twoq_gates,\\n        \\\"*\\\",\\n        label=f\\\"Two-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        twoq_curve(depths),\\n        label=f\\\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\\n\\n    plt.ylabel(\\\"Number of one-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_oneq_gates,\\n        \\\"*\\\",\\n        label=f\\\"One-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        oneq_curve(depths),\\n        label=f\\\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\";\n",
-       "                var nbb_formatted_code = \"def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\\n    \\\"\\\"\\\"Analyze the number of two-qubit and single-qubit gates.\\\"\\\"\\\"\\n\\n    depths = [1, 3, 5, 7, 9, 12]\\n\\n    num_twoq_gates = np.zeros(len(depths))\\n    num_oneq_gates = np.zeros(len(depths))\\n    for trial in range(num_trials):  # Average over different seeds\\n        num_twoq_gates_trial = []\\n        num_oneq_gates_trial = []\\n\\n        for depth in depths:\\n            if circuit_type_to_analyze == \\\"rb\\\":\\n                circuit, _ = get_rb_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n            elif circuit_type_to_analyze == \\\"mirror\\\":\\n                circuit, _ = get_mirror_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n\\n            # Compile to native gate set\\n            if hardware_type == \\\"rigetti\\\":\\n                circuit = compile_to_rigetti_gateset(circuit)\\n\\n            num_twoq_gates_trial.append(get_num_twoq_count(circuit))\\n            num_oneq_gates_trial.append(get_oneq_count(circuit))\\n        num_twoq_gates += np.array(num_twoq_gates_trial)\\n        num_oneq_gates += np.array(num_oneq_gates_trial)\\n\\n    num_twoq_gates /= num_trials\\n    num_oneq_gates /= num_trials\\n\\n    twoq_params = np.polyfit(depths, num_twoq_gates, 1)\\n    twoq_curve = np.poly1d(twoq_params)\\n\\n    oneq_params = np.polyfit(depths, num_oneq_gates, 1)\\n    oneq_curve = np.poly1d(oneq_params)\\n\\n    print(\\\"depth\\\\tnum. twoq\\\\tnum oneq\\\")\\n    print(\\\"-----------------------------------\\\")\\n\\n    for d, twoq, oneq in zip(depths, num_twoq_gates, num_oneq_gates):\\n        print(f\\\"{d}\\\\t{twoq}\\\\t\\\\t{oneq}\\\")\\n\\n    plt.ylabel(\\\"Number of two-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_twoq_gates,\\n        \\\"*\\\",\\n        label=f\\\"Two-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        twoq_curve(depths),\\n        label=f\\\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\\n\\n    plt.ylabel(\\\"Number of one-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_oneq_gates,\\n        \\\"*\\\",\\n        label=f\\\"One-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        oneq_curve(depths),\\n        label=f\\\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\n",
     "    \"\"\"Analyze the number of two-qubit and single-qubit gates.\"\"\"\n",
@@ -718,14 +424,11 @@
     "        num_oneq_gates_trial = []\n",
     "\n",
     "        for depth in depths:\n",
+    "            circuit_seed = seed + (10**3) * depth + (10**6) * trial\n",
     "            if circuit_type_to_analyze == \"rb\":\n",
-    "                circuit, _ = get_rb_circuit(\n",
-    "                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\n",
-    "                )\n",
+    "                circuit, _ = get_rb_circuit(depth=depth, seed=circuit_seed)\n",
     "            elif circuit_type_to_analyze == \"mirror\":\n",
-    "                circuit, _ = get_mirror_circuit(\n",
-    "                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\n",
-    "                )\n",
+    "                circuit, _ = get_mirror_circuit(depth=depth, seed=circuit_seed)\n",
     "\n",
     "            # Compile to native gate set\n",
     "            if hardware_type == \"rigetti\":\n",
@@ -753,41 +456,31 @@
     "\n",
     "    plt.ylabel(\"Number of two-qubit gates\")\n",
     "    plt.xlabel(\"d\")\n",
-    "    plt.plot(\n",
-    "        depths,\n",
-    "        num_twoq_gates,\n",
-    "        \"*\",\n",
-    "        label=f\"Two-qubit gates in {circuit_type_to_analyze} circuits\",\n",
-    "    )\n",
-    "    plt.plot(\n",
-    "        depths,\n",
-    "        twoq_curve(depths),\n",
-    "        label=f\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\",\n",
-    "    )\n",
+    "    plt.plot(depths, num_twoq_gates, \"*\", label=f\"Two-qubit gates in {circuit_type_to_analyze} circuits\")\n",
+    "    plt.plot(depths, twoq_curve(depths), label=f\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\")\n",
     "    plt.legend()\n",
     "    plt.show()\n",
     "\n",
     "    plt.ylabel(\"Number of one-qubit gates\")\n",
     "    plt.xlabel(\"d\")\n",
-    "    plt.plot(\n",
-    "        depths,\n",
-    "        num_oneq_gates,\n",
-    "        \"*\",\n",
-    "        label=f\"One-qubit gates in {circuit_type_to_analyze} circuits\",\n",
-    "    )\n",
-    "    plt.plot(\n",
-    "        depths,\n",
-    "        oneq_curve(depths),\n",
-    "        label=f\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\",\n",
-    "    )\n",
+    "    plt.plot(depths, num_oneq_gates, \"*\", label=f\"One-qubit gates in {circuit_type_to_analyze} circuits\")\n",
+    "    plt.plot(depths, oneq_curve(depths), label=f\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\")\n",
     "    plt.legend()\n",
     "    plt.show()"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "2bb15ad3",
+   "metadata": {},
+   "source": [
+    "### RB circuits"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "69329068",
+   "execution_count": 10,
+   "id": "f226161a",
    "metadata": {},
    "outputs": [
     {
@@ -827,33 +520,6 @@
       "needs_background": "light"
      },
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 11;\n",
-       "                var nbb_unformatted_code = \"count_gates(\\\"rb\\\", num_trials=10, seed=0)\";\n",
-       "                var nbb_formatted_code = \"count_gates(\\\"rb\\\", num_trials=10, seed=0)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -861,9 +527,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "97d8ee58",
+   "metadata": {},
+   "source": [
+    "### Mirror circuits"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "1b0ae199",
+   "execution_count": 11,
+   "id": "ef8b72e4",
    "metadata": {
     "scrolled": true
    },
@@ -905,33 +579,6 @@
       "needs_background": "light"
      },
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/javascript": [
-       "\n",
-       "            setTimeout(function() {\n",
-       "                var nbb_cell_id = 12;\n",
-       "                var nbb_unformatted_code = \"count_gates(\\\"mirror\\\", num_trials=10, seed=0)\";\n",
-       "                var nbb_formatted_code = \"count_gates(\\\"mirror\\\", num_trials=10, seed=0)\";\n",
-       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
-       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
-       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
-       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
-       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
-       "                        }\n",
-       "                        break;\n",
-       "                    }\n",
-       "                }\n",
-       "            }, 500);\n",
-       "            "
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -941,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3251808d",
+   "id": "905573d0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/qem-on-hardware/count_number_of_gates.ipynb
+++ b/qem-on-hardware/count_number_of_gates.ipynb
@@ -1,0 +1,976 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d97713d9",
+   "metadata": {},
+   "source": [
+    "# Counting gates in benchmark circuits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b62ba675",
+   "metadata": {},
+   "source": [
+    "**Description**\n",
+    "\n",
+    "Estimates the number of two-qubit gates and single-qubit gates for different randomized benchmarking circuits and for different mirror circuits. Both types of circuits are generated for different values of the abstract depth parameter $d$. The aim of this notebook is to estimate a relationship between $d$ and the actual number of physical gates."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91eef3e0",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9a9db726",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 1;\n",
+       "                var nbb_unformatted_code = \"%load_ext nb_black\";\n",
+       "                var nbb_formatted_code = \"%load_ext nb_black\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%load_ext nb_black"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cdac8249",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/andrea/anaconda3/lib/python3.7/site-packages/ipykernel_launcher.py:20: DeprecationWarning: The qiskit.ignis package is deprecated and has been supersceded by the qiskit-experiments project. Refer to the migration guide: https://github.com/Qiskit/qiskit-ignis#migration-guide on how to migrate to the new project.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 2;\n",
+       "                var nbb_unformatted_code = \"import os\\nimport functools\\nimport time\\nfrom typing import Dict, List, Tuple, Union\\n\\n# Plotting imports.\\nimport matplotlib.pyplot as plt\\n\\n%matplotlib inline\\nplt.rcParams.update({\\\"font.family\\\": \\\"serif\\\", \\\"font.size\\\": 12})\\n\\n# Third-party imports.\\nimport cirq\\nimport networkx as nx\\nimport numpy as np\\nimport pandas as pd\\n\\n# Qiskit imports.\\nimport qiskit\\nimport qiskit.ignis.verification.randomized_benchmarking as rb\\nfrom qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\\nfrom qiskit.circuit import Gate\\n\\n# Mitiq imports.\\nfrom mitiq.interface import convert_to_mitiq, convert_from_mitiq\\nfrom mitiq import benchmarks, pec, zne\\n\\n# For hardware device offerings.\\nfrom braket.aws import AwsDevice\\nfrom braket.devices import LocalSimulator\\nfrom braket.circuits import Circuit, gates, Noise\";\n",
+       "                var nbb_formatted_code = \"import os\\nimport functools\\nimport time\\nfrom typing import Dict, List, Tuple, Union\\n\\n# Plotting imports.\\nimport matplotlib.pyplot as plt\\n\\n%matplotlib inline\\nplt.rcParams.update({\\\"font.family\\\": \\\"serif\\\", \\\"font.size\\\": 12})\\n\\n# Third-party imports.\\nimport cirq\\nimport networkx as nx\\nimport numpy as np\\nimport pandas as pd\\n\\n# Qiskit imports.\\nimport qiskit\\nimport qiskit.ignis.verification.randomized_benchmarking as rb\\nfrom qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\\nfrom qiskit.circuit import Gate\\n\\n# Mitiq imports.\\nfrom mitiq.interface import convert_to_mitiq, convert_from_mitiq\\nfrom mitiq import benchmarks, pec, zne\\n\\n# For hardware device offerings.\\nfrom braket.aws import AwsDevice\\nfrom braket.devices import LocalSimulator\\nfrom braket.circuits import Circuit, gates, Noise\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import functools\n",
+    "import time\n",
+    "from typing import Dict, List, Tuple, Union\n",
+    "\n",
+    "# Plotting imports.\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline\n",
+    "plt.rcParams.update({\"font.family\": \"serif\", \"font.size\": 12})\n",
+    "\n",
+    "# Third-party imports.\n",
+    "import cirq\n",
+    "import networkx as nx\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Qiskit imports.\n",
+    "import qiskit\n",
+    "import qiskit.ignis.verification.randomized_benchmarking as rb\n",
+    "from qiskit.transpiler.passes import RemoveBarriers, RemoveFinalMeasurements\n",
+    "from qiskit.circuit import Gate\n",
+    "\n",
+    "# Mitiq imports.\n",
+    "from mitiq.interface import convert_to_mitiq, convert_from_mitiq\n",
+    "from mitiq import benchmarks, pec, zne\n",
+    "\n",
+    "# For hardware device offerings.\n",
+    "from braket.aws import AwsDevice\n",
+    "from braket.devices import LocalSimulator\n",
+    "from braket.circuits import Circuit, gates, Noise"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49929d1d",
+   "metadata": {},
+   "source": [
+    "### Parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e8b12ab9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Qubit indeces: [0, 1, 2]\n",
+      "RB pattern: [[0, 1], [2]]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 3;\n",
+       "                var nbb_unformatted_code = \"# Benchmark circuit type. Supported types are \\\"rb\\\" and \\\"mirror\\\".\\ncircuit_type: str = \\\"rb\\\"  \\n\\n# Qubits to use on the experiment. \\nnum_qubits = 3\\n\\nqubits = [j for j in range(num_qubits)]\\n\\n# Split qubits into 2-qubit pairs (assuming a chain connectivity). \\nrb_pattern = [[qa, qb] for qa, qb in zip(qubits[0:-1:2], qubits[1::2])]\\nif len(qubits) % 2 == 1:\\n    # For an odd number of qubits, append final individual qubit to the RB pattern.\\n    rb_pattern.append([qubits[-1]])\\nprint(\\\"Qubit indeces:\\\", qubits)\\nprint(\\\"RB pattern:\\\", rb_pattern)\";\n",
+       "                var nbb_formatted_code = \"# Benchmark circuit type. Supported types are \\\"rb\\\" and \\\"mirror\\\".\\ncircuit_type: str = \\\"rb\\\"\\n\\n# Qubits to use on the experiment.\\nnum_qubits = 3\\n\\nqubits = [j for j in range(num_qubits)]\\n\\n# Split qubits into 2-qubit pairs (assuming a chain connectivity).\\nrb_pattern = [[qa, qb] for qa, qb in zip(qubits[0:-1:2], qubits[1::2])]\\nif len(qubits) % 2 == 1:\\n    # For an odd number of qubits, append final individual qubit to the RB pattern.\\n    rb_pattern.append([qubits[-1]])\\nprint(\\\"Qubit indeces:\\\", qubits)\\nprint(\\\"RB pattern:\\\", rb_pattern)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Benchmark circuit type. Supported types are \"rb\" and \"mirror\".\n",
+    "circuit_type: str = \"rb\"  \n",
+    "\n",
+    "# Qubits to use on the experiment. \n",
+    "num_qubits = 3\n",
+    "\n",
+    "qubits = [j for j in range(num_qubits)]\n",
+    "\n",
+    "# Split qubits into 2-qubit pairs (assuming a chain connectivity). \n",
+    "rb_pattern = [[qa, qb] for qa, qb in zip(qubits[0:-1:2], qubits[1::2])]\n",
+    "if len(qubits) % 2 == 1:\n",
+    "    # For an odd number of qubits, append final individual qubit to the RB pattern.\n",
+    "    rb_pattern.append([qubits[-1]])\n",
+    "print(\"Qubit indeces:\", qubits)\n",
+    "print(\"RB pattern:\", rb_pattern)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c57056f",
+   "metadata": {},
+   "source": [
+    "### Hardware parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "36ebb12c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 4;\n",
+       "                var nbb_unformatted_code = \"# Hardware backend device type. Supported types are \\\"rigetti\\\", \\\"ibmq\\\", and \\\"ionq\\\".\\nhardware_type: str = \\\"ibmq\\\"\";\n",
+       "                var nbb_formatted_code = \"# Hardware backend device type. Supported types are \\\"rigetti\\\", \\\"ibmq\\\", and \\\"ionq\\\".\\nhardware_type: str = \\\"ibmq\\\"\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Hardware backend device type. Supported types are \"rigetti\", \"ibmq\", and \"ionq\".\n",
+    "hardware_type: str = \"ibmq\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8f3f9a8",
+   "metadata": {},
+   "source": [
+    "### Hardware architecture\n",
+    "\n",
+    "If the user selects the option to run on an actual hardware offering, define the architectural layout of the quantum device. Otherwise, invoke the appropriate simulator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d0ecec92",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computer connectivity (used only for mirror circuits): [(0, 1), (1, 0), (1, 2), (2, 1)]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 5;\n",
+       "                var nbb_unformatted_code = \"computer = nx.Graph()\\n\\n# Assume chain-like connectivity\\ncomputer.add_edges_from([(qa, qb) for qa, qb in zip(qubits[:-1], qubits[1:])])\\n\\n# Add reversed edges to computer graph.\\n# This is important to represent CNOT gates with target and control reversed.\\ncomputer = nx.to_directed(computer)\\n\\n\\n# Check if RB-pattern is consistent with device topology.\\nfor edge in rb_pattern:\\n    if len(edge) == 2:\\n        if edge not in computer.edges:\\n            raise ValueError(\\n                \\\"The option rb_pattern is not consistent with the device topology.\\\"\\n            )\\n\\nprint(\\\"Computer connectivity (used only for mirror circuits):\\\", computer.edges)\";\n",
+       "                var nbb_formatted_code = \"computer = nx.Graph()\\n\\n# Assume chain-like connectivity\\ncomputer.add_edges_from([(qa, qb) for qa, qb in zip(qubits[:-1], qubits[1:])])\\n\\n# Add reversed edges to computer graph.\\n# This is important to represent CNOT gates with target and control reversed.\\ncomputer = nx.to_directed(computer)\\n\\n\\n# Check if RB-pattern is consistent with device topology.\\nfor edge in rb_pattern:\\n    if len(edge) == 2:\\n        if edge not in computer.edges:\\n            raise ValueError(\\n                \\\"The option rb_pattern is not consistent with the device topology.\\\"\\n            )\\n\\nprint(\\\"Computer connectivity (used only for mirror circuits):\\\", computer.edges)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "computer = nx.Graph()\n",
+    "\n",
+    "# Assume chain-like connectivity\n",
+    "computer.add_edges_from([(qa, qb) for qa, qb in zip(qubits[:-1], qubits[1:])])\n",
+    "\n",
+    "# Add reversed edges to computer graph.\n",
+    "# This is important to represent CNOT gates with target and control reversed.\n",
+    "computer = nx.to_directed(computer)\n",
+    "\n",
+    "\n",
+    "# Check if RB-pattern is consistent with device topology.\n",
+    "for edge in rb_pattern:\n",
+    "    if len(edge) == 2:\n",
+    "        if edge not in computer.edges:\n",
+    "            raise ValueError(\n",
+    "                \"The option rb_pattern is not consistent with the device topology.\"\n",
+    "            )\n",
+    "\n",
+    "print(\"Computer connectivity (used only for mirror circuits):\", computer.edges)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59a7f99c",
+   "metadata": {},
+   "source": [
+    "### Benchmark circuit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3210e6fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 6;\n",
+       "                var nbb_unformatted_code = \"def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\\n    \\\"\\\"\\\"Extract qubit number assuming \\\"_\\\" is used as a word separator.\\\"\\\"\\\"\\n    digits = [int(s) for s in named_qubit.name.split(\\\"_\\\") if s.isdigit()]\\n    if len(digits) == 1:\\n        return cirq.LineQubit(digits[0])\\n    else:\\n        raise RuntimeError(\\\"Failed to identify qubit number.\\\")\";\n",
+       "                var nbb_formatted_code = \"def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\\n    \\\"\\\"\\\"Extract qubit number assuming \\\"_\\\" is used as a word separator.\\\"\\\"\\\"\\n    digits = [int(s) for s in named_qubit.name.split(\\\"_\\\") if s.isdigit()]\\n    if len(digits) == 1:\\n        return cirq.LineQubit(digits[0])\\n    else:\\n        raise RuntimeError(\\\"Failed to identify qubit number.\\\")\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def named_qubit_to_line_qubit(named_qubit: str) -> cirq.LineQubit:\n",
+    "    \"\"\"Extract qubit number assuming \"_\" is used as a word separator.\"\"\"\n",
+    "    digits = [int(s) for s in named_qubit.name.split(\"_\") if s.isdigit()]\n",
+    "    if len(digits) == 1:\n",
+    "        return cirq.LineQubit(digits[0])\n",
+    "    else:\n",
+    "        raise RuntimeError(\"Failed to identify qubit number.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b2140186",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 7;\n",
+       "                var nbb_unformatted_code = \"def get_rb_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n    circuit = rb.randomized_benchmarking_seq(\\n        length_vector=[depth],\\n        rb_pattern=rb_pattern,\\n        group_gates=\\\"0\\\",\\n        rand_seed=seed,\\n    )[0][0][0]\\n\\n    # Remove barriers and measurements.\\n    circuit = RemoveFinalMeasurements()(RemoveBarriers()(circuit))\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        # Qiskit --> Cirq.\\n        cirq_circuit, _ = convert_to_mitiq(circuit)\\n        circuit_with_linequbits = cirq_circuit.transform_qubits(\\n            named_qubit_to_line_qubit\\n        )\\n\\n        # Cirq --> Braket.\\n        return convert_from_mitiq(circuit_with_linequbits, \\\"braket\\\"), \\\"0\\\" * len(qubits)\\n\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Hack: Remove classical register and rename qubit register.\\n        return convert_from_mitiq(convert_to_mitiq(circuit)[0], \\\"qiskit\\\"), \\\"0\\\" * len(\\n            qubits\\n        )\\n\\n\\ndef get_mirror_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n\\n    return_type = (\\n        \\\"braket\\\" if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\" else \\\"qiskit\\\"\\n    )\\n    circuit, correct_bitstring = benchmarks.generate_mirror_circuit(\\n        nlayers=depth,\\n        two_qubit_gate_prob=1.0,\\n        connectivity_graph=computer,\\n        two_qubit_gate_name=\\\"CNOT\\\",\\n        seed=seed,\\n        return_type=return_type,\\n    )\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return circuit, correct_bitstring\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Reversed because Qiskit is wrong endian.\\n        return circuit, \\\"\\\".join(map(str, correct_bitstring[::-1]))\";\n",
+       "                var nbb_formatted_code = \"def get_rb_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n    circuit = rb.randomized_benchmarking_seq(\\n        length_vector=[depth],\\n        rb_pattern=rb_pattern,\\n        group_gates=\\\"0\\\",\\n        rand_seed=seed,\\n    )[0][0][0]\\n\\n    # Remove barriers and measurements.\\n    circuit = RemoveFinalMeasurements()(RemoveBarriers()(circuit))\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        # Qiskit --> Cirq.\\n        cirq_circuit, _ = convert_to_mitiq(circuit)\\n        circuit_with_linequbits = cirq_circuit.transform_qubits(\\n            named_qubit_to_line_qubit\\n        )\\n\\n        # Cirq --> Braket.\\n        return convert_from_mitiq(circuit_with_linequbits, \\\"braket\\\"), \\\"0\\\" * len(qubits)\\n\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Hack: Remove classical register and rename qubit register.\\n        return convert_from_mitiq(convert_to_mitiq(circuit)[0], \\\"qiskit\\\"), \\\"0\\\" * len(\\n            qubits\\n        )\\n\\n\\ndef get_mirror_circuit(\\n    depth: int, seed: int\\n) -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\\n\\n    return_type = (\\n        \\\"braket\\\" if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\" else \\\"qiskit\\\"\\n    )\\n    circuit, correct_bitstring = benchmarks.generate_mirror_circuit(\\n        nlayers=depth,\\n        two_qubit_gate_prob=1.0,\\n        connectivity_graph=computer,\\n        two_qubit_gate_name=\\\"CNOT\\\",\\n        seed=seed,\\n        return_type=return_type,\\n    )\\n\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return circuit, correct_bitstring\\n    elif hardware_type == \\\"ibmq\\\":\\n        # Reversed because Qiskit is wrong endian.\\n        return circuit, \\\"\\\".join(map(str, correct_bitstring[::-1]))\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def get_rb_circuit(\n",
+    "    depth: int, seed: int\n",
+    ") -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\n",
+    "    circuit = rb.randomized_benchmarking_seq(\n",
+    "        length_vector=[depth],\n",
+    "        rb_pattern=rb_pattern,\n",
+    "        group_gates=\"0\",\n",
+    "        rand_seed=seed,\n",
+    "    )[0][0][0]\n",
+    "\n",
+    "    # Remove barriers and measurements.\n",
+    "    circuit = RemoveFinalMeasurements()(RemoveBarriers()(circuit))\n",
+    "\n",
+    "    if hardware_type == \"ionq\" or hardware_type == \"rigetti\":\n",
+    "        # Qiskit --> Cirq.\n",
+    "        cirq_circuit, _ = convert_to_mitiq(circuit)\n",
+    "        circuit_with_linequbits = cirq_circuit.transform_qubits(\n",
+    "            named_qubit_to_line_qubit\n",
+    "        )\n",
+    "\n",
+    "        # Cirq --> Braket.\n",
+    "        return convert_from_mitiq(circuit_with_linequbits, \"braket\"), \"0\" * len(qubits)\n",
+    "\n",
+    "    elif hardware_type == \"ibmq\":\n",
+    "        # Hack: Remove classical register and rename qubit register.\n",
+    "        return convert_from_mitiq(convert_to_mitiq(circuit)[0], \"qiskit\"), \"0\" * len(\n",
+    "            qubits\n",
+    "        )\n",
+    "\n",
+    "\n",
+    "def get_mirror_circuit(\n",
+    "    depth: int, seed: int\n",
+    ") -> Union[Tuple[cirq.Circuit, str], Tuple[qiskit.QuantumCircuit, str]]:\n",
+    "\n",
+    "    return_type = (\n",
+    "        \"braket\" if hardware_type == \"ionq\" or hardware_type == \"rigetti\" else \"qiskit\"\n",
+    "    )\n",
+    "    circuit, correct_bitstring = benchmarks.generate_mirror_circuit(\n",
+    "        nlayers=depth,\n",
+    "        two_qubit_gate_prob=1.0,\n",
+    "        connectivity_graph=computer,\n",
+    "        two_qubit_gate_name=\"CNOT\",\n",
+    "        seed=seed,\n",
+    "        return_type=return_type,\n",
+    "    )\n",
+    "\n",
+    "    if hardware_type == \"ionq\" or hardware_type == \"rigetti\":\n",
+    "        return circuit, correct_bitstring\n",
+    "    elif hardware_type == \"ibmq\":\n",
+    "        # Reversed because Qiskit is wrong endian.\n",
+    "        return circuit, \"\".join(map(str, correct_bitstring[::-1]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "88f1838e",
+   "metadata": {},
+   "source": [
+    "### Gateset compilation functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "552cb84f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 8;\n",
+       "                var nbb_unformatted_code = \"def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\\n    \\\"\\\"\\\"Compiles AWS gates to Rigetti gateset. Taken from:\\n    https://mitiq.readthedocs.io/en/stable/examples/braket_mirror_circuit.html\\\"\\\"\\\"\\n    compiled = Circuit()\\n\\n    for instr in circuit.instructions:\\n        if isinstance(instr.operator, gates.Vi):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.V):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Ry):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-instr.operator.angle), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Y):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.X):\\n            compiled.add_instruction(gates.Instruction(gates.Rx(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.Z):\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.S):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Si):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.H):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.CNot):\\n            # First Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n\\n            # Controlled-Z\\n            compiled.add_instruction(gates.Instruction(gates.CZ(), instr.target))\\n\\n            # Second Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n        else:\\n            compiled.add_instruction(instr)\\n\\n    return compiled\";\n",
+       "                var nbb_formatted_code = \"def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\\n    \\\"\\\"\\\"Compiles AWS gates to Rigetti gateset. Taken from:\\n    https://mitiq.readthedocs.io/en/stable/examples/braket_mirror_circuit.html\\\"\\\"\\\"\\n    compiled = Circuit()\\n\\n    for instr in circuit.instructions:\\n        if isinstance(instr.operator, gates.Vi):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.V):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Ry):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-instr.operator.angle), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Y):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.X):\\n            compiled.add_instruction(gates.Instruction(gates.Rx(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.Z):\\n            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\\n        elif isinstance(instr.operator, gates.S):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.Si):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(-np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.H):\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\\n            )\\n        elif isinstance(instr.operator, gates.CNot):\\n            # First Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n\\n            # Controlled-Z\\n            compiled.add_instruction(gates.Instruction(gates.CZ(), instr.target))\\n\\n            # Second Hadamard\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\\n            )\\n            compiled.add_instruction(\\n                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\\n            )\\n        else:\\n            compiled.add_instruction(instr)\\n\\n    return compiled\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def compile_to_rigetti_gateset(circuit: Circuit) -> Circuit:\n",
+    "    \"\"\"Compiles AWS gates to Rigetti gateset. Taken from:\n",
+    "    https://mitiq.readthedocs.io/en/stable/examples/braket_mirror_circuit.html\"\"\"\n",
+    "    compiled = Circuit()\n",
+    "\n",
+    "    for instr in circuit.instructions:\n",
+    "        if isinstance(instr.operator, gates.Vi):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.V):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.Ry):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(-instr.operator.angle), instr.target)\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.Y):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(-np.pi / 2), instr.target)\n",
+    "            )\n",
+    "            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.X):\n",
+    "            compiled.add_instruction(gates.Instruction(gates.Rx(np.pi), instr.target))\n",
+    "        elif isinstance(instr.operator, gates.Z):\n",
+    "            compiled.add_instruction(gates.Instruction(gates.Rz(np.pi), instr.target))\n",
+    "        elif isinstance(instr.operator, gates.S):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.Si):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(-np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.H):\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target)\n",
+    "            )\n",
+    "        elif isinstance(instr.operator, gates.CNot):\n",
+    "            # First Hadamard\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "\n",
+    "            # Controlled-Z\n",
+    "            compiled.add_instruction(gates.Instruction(gates.CZ(), instr.target))\n",
+    "\n",
+    "            # Second Hadamard\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rx(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "            compiled.add_instruction(\n",
+    "                gates.Instruction(gates.Rz(np.pi / 2), instr.target[1])\n",
+    "            )\n",
+    "        else:\n",
+    "            compiled.add_instruction(instr)\n",
+    "\n",
+    "    return compiled"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d22b993",
+   "metadata": {},
+   "source": [
+    "### CNOT count utility functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "120631e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 9;\n",
+       "                var nbb_unformatted_code = \"def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    \\\"\\\"\\\"Determine number of two-qubit gates in a given `Circuit` object.\\\"\\\"\\\"\\n\\n    # Count CNOT gates for `cirq`-type circuit objects:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        num_cnots: int = 0\\n        for instruction in circuit.instructions:\\n            if isinstance(instruction.operator, gates.CNot) or isinstance(\\n                instruction.operator, gates.CZ\\n            ):\\n                num_cnots += 1\\n        return num_cnots\\n\\n    # Count CNOT gates for `qiskit`-type circuit objects:\\n    elif hardware_type == \\\"ibmq\\\":\\n        return circuit.count_ops().get(\\\"cx\\\")\\n\\n\\ndef get_oneq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return len(circuit.instructions) - get_num_twoq_count(circuit)\\n    elif hardware_type == \\\"ibmq\\\":\\n        return len(circuit) - get_num_twoq_count(circuit)\";\n",
+       "                var nbb_formatted_code = \"def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    \\\"\\\"\\\"Determine number of two-qubit gates in a given `Circuit` object.\\\"\\\"\\\"\\n\\n    # Count CNOT gates for `cirq`-type circuit objects:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        num_cnots: int = 0\\n        for instruction in circuit.instructions:\\n            if isinstance(instruction.operator, gates.CNot) or isinstance(\\n                instruction.operator, gates.CZ\\n            ):\\n                num_cnots += 1\\n        return num_cnots\\n\\n    # Count CNOT gates for `qiskit`-type circuit objects:\\n    elif hardware_type == \\\"ibmq\\\":\\n        return circuit.count_ops().get(\\\"cx\\\")\\n\\n\\ndef get_oneq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\\n    if hardware_type == \\\"ionq\\\" or hardware_type == \\\"rigetti\\\":\\n        return len(circuit.instructions) - get_num_twoq_count(circuit)\\n    elif hardware_type == \\\"ibmq\\\":\\n        return len(circuit) - get_num_twoq_count(circuit)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def get_num_twoq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\n",
+    "    \"\"\"Determine number of two-qubit gates in a given `Circuit` object.\"\"\"\n",
+    "\n",
+    "    # Count CNOT gates for `cirq`-type circuit objects:\n",
+    "    if hardware_type == \"ionq\" or hardware_type == \"rigetti\":\n",
+    "        num_cnots: int = 0\n",
+    "        for instruction in circuit.instructions:\n",
+    "            if isinstance(instruction.operator, gates.CNot) or isinstance(\n",
+    "                instruction.operator, gates.CZ\n",
+    "            ):\n",
+    "                num_cnots += 1\n",
+    "        return num_cnots\n",
+    "\n",
+    "    # Count CNOT gates for `qiskit`-type circuit objects:\n",
+    "    elif hardware_type == \"ibmq\":\n",
+    "        return circuit.count_ops().get(\"cx\")\n",
+    "\n",
+    "\n",
+    "def get_oneq_count(circuit: Union[cirq.Circuit, qiskit.QuantumCircuit]) -> int:\n",
+    "    if hardware_type == \"ionq\" or hardware_type == \"rigetti\":\n",
+    "        return len(circuit.instructions) - get_num_twoq_count(circuit)\n",
+    "    elif hardware_type == \"ibmq\":\n",
+    "        return len(circuit) - get_num_twoq_count(circuit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7105282",
+   "metadata": {},
+   "source": [
+    "## Analyze the number of gates in RB circuits and in mirror circuits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8db26c58",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 10;\n",
+       "                var nbb_unformatted_code = \"def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\\n    \\\"\\\"\\\"Analyze the number of two-qubit and single-qubit gates.\\\"\\\"\\\"\\n\\n    depths = [1, 3, 5, 7, 9, 12]\\n\\n    num_twoq_gates = np.zeros(len(depths))\\n    num_oneq_gates = np.zeros(len(depths))\\n    for trial in range(num_trials):  # Average over different seeds\\n        num_twoq_gates_trial = []\\n        num_oneq_gates_trial = []\\n\\n        for depth in depths:\\n            if circuit_type_to_analyze == \\\"rb\\\":\\n                circuit, _ = get_rb_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n            elif circuit_type_to_analyze == \\\"mirror\\\":\\n                circuit, _ = get_mirror_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n\\n            # Compile to native gate set\\n            if hardware_type == \\\"rigetti\\\":\\n                circuit = compile_to_rigetti_gateset(circuit)\\n\\n            num_twoq_gates_trial.append(get_num_twoq_count(circuit))\\n            num_oneq_gates_trial.append(get_oneq_count(circuit))\\n        num_twoq_gates += np.array(num_twoq_gates_trial)\\n        num_oneq_gates += np.array(num_oneq_gates_trial)\\n\\n    num_twoq_gates /= num_trials\\n    num_oneq_gates /= num_trials\\n\\n    twoq_params = np.polyfit(depths, num_twoq_gates, 1)\\n    twoq_curve = np.poly1d(twoq_params)\\n\\n    oneq_params = np.polyfit(depths, num_oneq_gates, 1)\\n    oneq_curve = np.poly1d(oneq_params)\\n\\n    print(\\\"depth\\\\tnum. twoq\\\\tnum oneq\\\")\\n    print(\\\"-----------------------------------\\\")\\n\\n    for d, twoq, oneq in zip(depths, num_twoq_gates, num_oneq_gates):\\n        print(f\\\"{d}\\\\t{twoq}\\\\t\\\\t{oneq}\\\")\\n\\n    plt.ylabel(\\\"Number of two-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_twoq_gates,\\n        \\\"*\\\",\\n        label=f\\\"Two-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        twoq_curve(depths),\\n        label=f\\\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\\n\\n    plt.ylabel(\\\"Number of one-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_oneq_gates,\\n        \\\"*\\\",\\n        label=f\\\"One-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        oneq_curve(depths),\\n        label=f\\\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\";\n",
+       "                var nbb_formatted_code = \"def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\\n    \\\"\\\"\\\"Analyze the number of two-qubit and single-qubit gates.\\\"\\\"\\\"\\n\\n    depths = [1, 3, 5, 7, 9, 12]\\n\\n    num_twoq_gates = np.zeros(len(depths))\\n    num_oneq_gates = np.zeros(len(depths))\\n    for trial in range(num_trials):  # Average over different seeds\\n        num_twoq_gates_trial = []\\n        num_oneq_gates_trial = []\\n\\n        for depth in depths:\\n            if circuit_type_to_analyze == \\\"rb\\\":\\n                circuit, _ = get_rb_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n            elif circuit_type_to_analyze == \\\"mirror\\\":\\n                circuit, _ = get_mirror_circuit(\\n                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\\n                )\\n\\n            # Compile to native gate set\\n            if hardware_type == \\\"rigetti\\\":\\n                circuit = compile_to_rigetti_gateset(circuit)\\n\\n            num_twoq_gates_trial.append(get_num_twoq_count(circuit))\\n            num_oneq_gates_trial.append(get_oneq_count(circuit))\\n        num_twoq_gates += np.array(num_twoq_gates_trial)\\n        num_oneq_gates += np.array(num_oneq_gates_trial)\\n\\n    num_twoq_gates /= num_trials\\n    num_oneq_gates /= num_trials\\n\\n    twoq_params = np.polyfit(depths, num_twoq_gates, 1)\\n    twoq_curve = np.poly1d(twoq_params)\\n\\n    oneq_params = np.polyfit(depths, num_oneq_gates, 1)\\n    oneq_curve = np.poly1d(oneq_params)\\n\\n    print(\\\"depth\\\\tnum. twoq\\\\tnum oneq\\\")\\n    print(\\\"-----------------------------------\\\")\\n\\n    for d, twoq, oneq in zip(depths, num_twoq_gates, num_oneq_gates):\\n        print(f\\\"{d}\\\\t{twoq}\\\\t\\\\t{oneq}\\\")\\n\\n    plt.ylabel(\\\"Number of two-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_twoq_gates,\\n        \\\"*\\\",\\n        label=f\\\"Two-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        twoq_curve(depths),\\n        label=f\\\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\\n\\n    plt.ylabel(\\\"Number of one-qubit gates\\\")\\n    plt.xlabel(\\\"d\\\")\\n    plt.plot(\\n        depths,\\n        num_oneq_gates,\\n        \\\"*\\\",\\n        label=f\\\"One-qubit gates in {circuit_type_to_analyze} circuits\\\",\\n    )\\n    plt.plot(\\n        depths,\\n        oneq_curve(depths),\\n        label=f\\\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\\\",\\n    )\\n    plt.legend()\\n    plt.show()\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def count_gates(circuit_type_to_analyze: str, num_trials=100, seed=0):\n",
+    "    \"\"\"Analyze the number of two-qubit and single-qubit gates.\"\"\"\n",
+    "\n",
+    "    depths = [1, 3, 5, 7, 9, 12]\n",
+    "\n",
+    "    num_twoq_gates = np.zeros(len(depths))\n",
+    "    num_oneq_gates = np.zeros(len(depths))\n",
+    "    for trial in range(num_trials):  # Average over different seeds\n",
+    "        num_twoq_gates_trial = []\n",
+    "        num_oneq_gates_trial = []\n",
+    "\n",
+    "        for depth in depths:\n",
+    "            if circuit_type_to_analyze == \"rb\":\n",
+    "                circuit, _ = get_rb_circuit(\n",
+    "                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\n",
+    "                )\n",
+    "            elif circuit_type_to_analyze == \"mirror\":\n",
+    "                circuit, _ = get_mirror_circuit(\n",
+    "                    depth=depth, seed=seed + (10**3) * depth + (10**6) * trial\n",
+    "                )\n",
+    "\n",
+    "            # Compile to native gate set\n",
+    "            if hardware_type == \"rigetti\":\n",
+    "                circuit = compile_to_rigetti_gateset(circuit)\n",
+    "\n",
+    "            num_twoq_gates_trial.append(get_num_twoq_count(circuit))\n",
+    "            num_oneq_gates_trial.append(get_oneq_count(circuit))\n",
+    "        num_twoq_gates += np.array(num_twoq_gates_trial)\n",
+    "        num_oneq_gates += np.array(num_oneq_gates_trial)\n",
+    "\n",
+    "    num_twoq_gates /= num_trials\n",
+    "    num_oneq_gates /= num_trials\n",
+    "\n",
+    "    twoq_params = np.polyfit(depths, num_twoq_gates, 1)\n",
+    "    twoq_curve = np.poly1d(twoq_params)\n",
+    "\n",
+    "    oneq_params = np.polyfit(depths, num_oneq_gates, 1)\n",
+    "    oneq_curve = np.poly1d(oneq_params)\n",
+    "\n",
+    "    print(\"depth\\tnum. twoq\\tnum oneq\")\n",
+    "    print(\"-----------------------------------\")\n",
+    "\n",
+    "    for d, twoq, oneq in zip(depths, num_twoq_gates, num_oneq_gates):\n",
+    "        print(f\"{d}\\t{twoq}\\t\\t{oneq}\")\n",
+    "\n",
+    "    plt.ylabel(\"Number of two-qubit gates\")\n",
+    "    plt.xlabel(\"d\")\n",
+    "    plt.plot(\n",
+    "        depths,\n",
+    "        num_twoq_gates,\n",
+    "        \"*\",\n",
+    "        label=f\"Two-qubit gates in {circuit_type_to_analyze} circuits\",\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        depths,\n",
+    "        twoq_curve(depths),\n",
+    "        label=f\"best fit: y={twoq_params[0]:.3} x + {twoq_params[1]:.3}\",\n",
+    "    )\n",
+    "    plt.legend()\n",
+    "    plt.show()\n",
+    "\n",
+    "    plt.ylabel(\"Number of one-qubit gates\")\n",
+    "    plt.xlabel(\"d\")\n",
+    "    plt.plot(\n",
+    "        depths,\n",
+    "        num_oneq_gates,\n",
+    "        \"*\",\n",
+    "        label=f\"One-qubit gates in {circuit_type_to_analyze} circuits\",\n",
+    "    )\n",
+    "    plt.plot(\n",
+    "        depths,\n",
+    "        oneq_curve(depths),\n",
+    "        label=f\"best fit: y={oneq_params[0]:.3} x + {oneq_params[1]:.3}\",\n",
+    "    )\n",
+    "    plt.legend()\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "69329068",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth\tnum. twoq\tnum oneq\n",
+      "-----------------------------------\n",
+      "1\t3.2\t\t22.4\n",
+      "3\t6.2\t\t44.5\n",
+      "5\t8.7\t\t64.3\n",
+      "7\t11.6\t\t79.9\n",
+      "9\t15.2\t\t107.9\n",
+      "12\t18.5\t\t134.7\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEMCAYAAADEXsFmAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAA5UUlEQVR4nO3deVxV5fb48c9CDTLRckLNqVFNLUsccAJTb05Z+TUrLcNKb3abu6ZlZZaWDZZZWdlkajb+Ksf0VkKpOaf3llpppomp4JQzCKzfH/t4AgTcyD4cOKz36+VLzt7nPHvtA5zFfvbzrEdUFWOMMSYs2AEYY4wpHiwhGGOMASwhGGOM8bGEYIwxBrCEYIwxxqdssAM4VVWrVtX69esHOwxjjClRVq1atUtVq+W2r8QmhPr167Ny5cpgh2GMMSWKiGzJa591GRljjAEsIRhjjPGxhGCMMQawhGCMMcanxN5Uzs/+/ftJTk7m2LFjwQ7FmFLhjDPOoHbt2oSF2d+YJVnIJYT9+/ezc+dOzj77bE4//XREJNghGRPSMjMz2bZtG7t27aJ69erBDscUQsil8+TkZM4++2zKly9vycCYIhAWFkZUVBR//fVXsEMxhRRyCeHYsWOcfvrpwQ7DmFKlXLlypKenBzuM0uHnOfDDlIA0HXIJAbArA2OKmP3OFYGDyfBJPHzYD36YCpmZnh8iJBOCMcaEDFVY8wG80gJ+nsPBtsO5If0xkg+leX4oSwhFqGHDhsTFxREXF0eNGjWIioryP27YsGGwwztBWloacXFxiAibN2/O9TnTp0/ntttuK9rAPLZo0SL+8Y9/eNaem/etILp3705iYmKh2wlW+6YQ9m6Bab3hi9uhWkO4fTFjD/Zk6Zb9TPh6g+eHk5K6hGZ0dLTmVsto/fr1NGrUKAgRnVxcXJz/Fy8+Pp709HSmTZt2wr7iRkT4/fffya2YYEZGBkeOHKFChQqAc17169fn8ccf9zyOzZs3c8455+D1z6yqsn//fipVquRpu/m9bwWxf/9+IiMjA9Ytk7P9U427OP/ulTiZGbDiLfh6FIhA58dpOLMWR3O5TRNeNoxfRndz3bSIrFLV6Nz22RVCDsn7j9L3jSUkHzjqedtPP/30Ke0rzsqUKeNPBiWViHieDLxUsWLFgPbRB7p9U0DJP8M7XeHLB6FeDNyxBFoO4rsHO9GrWS0iyjkf2xHlwriqWS0WDuvo2aEtIeQw4ZsNrNi8JyCXYzExMXnuq1atGueffz7Vq1dnzJgxAIwYMYJhw4YB8PbbbxMVFcUDDzwAwIoVK4iNjaVDhw7ExsayYsWKPNv+7bffaN++PTExMfTv35/evXtTv359Jk2axIABA4iIiPBfnVx11VW5dnXMmDGDrl270rhxY8aOHQvAjz/+SLNmzfx/Sb700kvMmzePyZMnExcXx9tvv51rPO+++y5NmjShU6dOTJgwARGhdevW/PHHH6xdu5YePXrQpUsXYmJimDRpEgB//fUX119/PYC/my0jI4Njx44xdOhQ2rRpQ7t27Rg1apT/CuL777+nXbt2XH755cTFxTF79uwTYklJSaF169b+D8Tly5f7z+m5554jNjaWiy++mF9//TXXc3niiSeoUaMGd911F/369aNBgwbEx8fn+77l5uDBgwwaNIh27drRrl07br31VlJSUnjuueeoUaOG/4rrjjvu4Mwzz+TRRx+ld+/e1K1b179v3LhxtG7dmo4dO9K9e3d++OEHpk+fTv369f0xvfbaa9nay9l+t27OX5rXX389cXFxbNu2zdX7aDyQngbfPgdvtIfdG+CaSdD/UzizLgDVK0YQGV6W1PRMwsuGkZqeSWR4WapHRngXg6oW2T+gBbARiM+x/VZgDfAdsBhodbK2mjdvrrlZt25drttP5sIRc7XesNkn/LtwxNxTau9kbr75Zu3fv3+2bV999ZVeeOGF/sfNmzfXJk2a+B/37dtXVVX37dunVapU0YSEBFVV/e6777RKlSq6d+/eXI/VsmVLfeqpp1RVNSkpSStWrKgjR470769Xr56/LVVVQH///fdsjx966CFVVd29e7fWqFFD58+fr6qqCQkJWq9evWznlbXtnH766Sc9/fTTddOmTaqqOmHChGzHW7p0qS5dulRVVdPS0rRhw4b666+/qqrq77//rs6P7N9Gjx6tHTt21PT0dE1LS9OYmBidOnWqqqq2aNHC39aaNWv05ptvzjWmnO0mJCRouXLldOHChaqqOmTIEB08eHCe53TzzTdrkyZN9NChQ7pv3z598sknT/q+5TRo0CAdOHCgqqpmZGTolVde6f+e5HxPY2NjtUuXLpqenq4///yzvvnmm/r+++9r48aN9dChQ6qq+txzz/lfM3LkyGznnrO9nI9zfv/dvo+n+rtnVDVppeqrMaojK6p+MlD1QHKuTxs8ZYWO+PxHXbvtLx3x+Y86eMqKAh8KWKl5fK4W2RWCiFwD3Af8lWN7E+AN4HpV7QC8DXwuRXwNu/DBjgG/HDuZDh06sH37djZu3Mi2bdu47LLL+PXXX9m6dSubNm3i3HPPBWD27NlUrFiRuLg4ANq3b89ZZ53FzJkzT2hzy5YtLF++nBtvvBGAs88+m9jY2ALHdu211wJQuXJlunfvzocffnhK5/jpp58SExPDOeecA0D//v2z7b/gggt4++23adOmDV26dGH79u2sXr06z/YmT57MzTffTJkyZShXrhzXXnstU6dO9cc6depUdu7cySWXXMLEiRNdx1mhQgXatWsHwMUXX8zvv/+e7/M7d+5M+fLlqVSpEo888oh/u5v3LTMzkylTpvj/ig8LC2PcuHFcdNFFeR6vR48elClThgYNGnDbbbfx7rvv0rdvX8qXLw/AoEGD6NOnj+vzzU9h3kdzEmmHYf4IeKszHNkD138Afd6BCrmuX8MbN0Uz+uomXFSrIqOvbsIbN+V6K+CUFWWX0QpV7QccyLG9EbBPVX/2PV4C1ARqFGFsRXM5dhKnnXYaXbp0YdasWcydO5frr7+e9u3bM2fOHGbPnk2PHj0ASEpKolq17D8w1apVIykpiXnz5vm7VMaOHcv27dsBqFq1qv+5lStXLnBsZ511lv/rKlWq+NstqO3bt+cby/33309ycjILFy4kMTGRZs2acfjw4TzbS0pK4oUXXvCf8/vvv09GRgbgjIAqX748l112GV27ds2z2yc3FStW9H8dERFBWlr+Q/zyugfh5n1LSUkhNTU12/f0ggsuyLcMRM7j5fyZqFSpEk2aNMk3ZrcK8z6afPz+HbwWA0tegctuhn8tg4bdgxpSkSUEVU3KY9dioIyItPE9vhLYDCQXRVxZ7TqYSv9W9fj8jrb0b1WPlIOpRR0CPXv2ZPbs2Xz//fe0b9+eHj16MHfuXJYsWeK/B1GnTh1SUlKyvS4lJYXatWvTtWtXEhMTSUxMZPjw4dSsWdO//7jdu3dne+1pp51Gaqpzrvv27cs1rj179vi/3rVrl7/dgqpZs2a+sSxfvpzOnTtTpkwZgJMWKKxTpw6PPPKI/5yXL1/Oxx9/DEBqairPPvssW7ZsoUOHDlx11VWnFHNhuHnfqlWrRnh4eLb35c8//2THjh2uj5PzZ+LQoUP88ssvQPbvL+T9Pc5LcXgfQ8qRfTDzLnjvSpAwuHk2XDkeIoI/sCHoN5VV9U/g/4D/JyK/AAOBK1Q1o6hjCfTlmBvdu3dn8eLFhIWFUa5cOXr27Mk333zD6aef7v+Q7NmzJwcOHOC7774DYPHixezdu5devXqd0F69evVo2bKlvxtl27ZtLF68ONtzzjnnHH766ScA5s6dm2tcx7s6du/e7b96yU1kZCSHDx/m0KFDJ3QHAfTp04clS5awadMmAP+H93Hnn38+y5YtA5yrif/973/Z2gY4fPgwY8eOZenSpcTHxzN9+nT/VcF7773nvynfp08fDh8+TNmyZWnbtq3/OUXJzfsWFhbGgAEDmDx5MuB0Id16660FSgjx8fF8/PHH/qup8ePHM2/ePMD5/q5btw5VZc+ePf73Ny8VKlTg8OHDTJs2jU8//bRYvI8hY/1seLUVrJ4Gbe+BId/DOe2DHdXf8rq5EKh/QCJZbioDDXGuBi72PR4EJABlcnntYGAlsLJu3bq53jApCTe2hg4dqlFRUVq9enUdOnToCftbtGih7733nv/xBRdcoNOnT8/2nJUrV2psbKy2b99eO3TooMuXL8/zeBs3btS2bdtq69atNT4+Xq+77rpsNxEXLlyoF154oXbq1EknT56sgLZq1Uo3b96ssbGxCuiYMWO0U6dO2qhRI/8N6v/97396ySWXaHh4uPbp00dVVb///ntt0KCBtmjRQt9///1c43nnnXf0oosu0k6dOumbb76pgG7evFlVVdevX6/NmzfX1q1b68CBA7Vp06baoEED/eabb1RVtV+/ftq8eXPt3LmzHj58WNPS0nTYsGHaqlUrjYuL0xtvvNF/Y/WZZ57RmJgYjYuL05YtW/rbyCo5OVlbtWqlgMbGxupPP/3kP6fBgwfrsmXLtEGDBlqpUqVcv1fjxo3TqKgorVevnn9/ampqvu9bbg4cOKC33nqrtm3bVmNiYvSVV15RVdVnn33W3/5bb72lQ4cO1UqVKmmDBg103Lhx2dp4/vnntVWrVtqhQwe97bbb9NixY6qqevjwYe3atateeumlOnjwYL3uuuv87eVsX1V12LBh2rRpU23btq1u377d1fuoWjJ+94LmwE7VjwY4N40ntlFNWhW0UMjnpnKRT0wTkURgsqpO9j1+Bmiqqt19jwXnxvO1qjo/r3ZK4sS04iKQk8fc2LNnj//eQUpKClFRURw8eNB/Q9SUTPa7lwtV+O+HMG84HDsMsQ9C23uhTLmghVTcJ6adBvg7in0ZLB2omOcrTImVnp5Or169yPQV5po6dSrt2rWzZGBCTy5lJ+gwNKjJ4GSKwwI5XwPvi0hNVd0uIt2BCGBpkOMKSWPGjGHevHlERERQq1YtBg8eXKTHL1OmDOeeey4xMTGUK1eOChUqMGVKYEr5GhMUOctOdH8eom+FErCaXJF1GYlIc2Ac0AzYAaxT1d6+ffcBA4CDOMngcVWdk1971mVkTPFiv3s4ZSdm3gVJy+H8ztDzRf9M4+Iivy6jIrtCUNVVQFwe+14EXiyqWIwxxlPpabB4PHz3HJx2hlN24uK+zhVCCVIcuoyMMabk2rYKZtwFyWuhyf9B12fynGlc3FlCMMaYU5F2GBLGwNKJUCHKKTsR5JnGheUqIYhIK+AKYCxQC5iMM0LpX6r6Y8CiM8aY4mjTtzDrbti7GZoPhC6jisVM48Jye4XwBPAKzvDQZ4CfgOW+bQWvlGaMMSXRkX3w1aPOIveVz3XKThSnmcaF5HYcVJiqzsKZG9ABeEBVpwDer/Icwo7Xzg/GhLDvvvuOyy67jJYtWxIfH8/tt99eLIZ77tixg3/84x/Z1hA4mZEjR+a6mteGDRto3rx50Cbc5VSQeMaMGUOzZs1o3749nTp1yrWA3N69eznrrLP8JS5MESvuZSc84DYhnCEiVYF/AZ+raqqIhAHFd4ZFMfTYY4/RtWtXz9uNi4s76YfEiBEj+Pe//83y5ctp1aoVzz//PP369fPvr1+/fpEv4blp0yZuuukmqlSp4vo1O3fu5K233jph+9KlS7nvvvuyVVINpoLEM3fuXJ577jm+/vprFi5cSNu2bRkwYMAJz3vqqaf8E/pMETqYDB/fDB/1hzOqwaAF0OUJKHd6sCPznNuE8AywFrgRGCMiNXC6jGzyWAmRlJRErVq1ABgyZAgVKlSgbNngjimoWLEis2bNokGDBq5f8+STTzJkyJATtterV48ZM2acchVWNxITE/1rUJxMQeJZu3Yt559/vj95xMTEsGbNmmzP2bp1K+vXr+fSSy8taNjmVKnCmunwSgv4ZS5c/igMToBaofs9cJUQVHWGqkap6kWquk1Vd6hqtKr+O9ABhqLk5GT69OlDy5Yt6dGjB7t27fLvmz9/PjExMcTGxnLllVfy559/Ak6Fz759+xIbG0u7du247777AHjooYdYs2YNY8eOJS4ujjlzTpzP17t3b7Zv3869995Lt27dmDp1arZlFQcOHMiOHTu49957iYuLY9WqVfnG/9prrxEZGUmjRo1YtGgRKSkpXHbZZZxzzjn8+KP7MQZVq1YlIsL9ehMbN27kzz//9C9ck1XNmjX91WDz8+OPP9KoUSPCw8N55ZVXmDlzJtWrVz+lRYPy4zYecBbX+e2339i4cSPgLIDUsmXLbM8ZOXJksekKKxX8ZSeGZCk78e9iXXbCC67/RPStV3ATEA7cgzOzeKIWdXW8gvpyOOwI8ECoGk2hW97r5ea0YMECVqxYQWRkJIMHD+buu+9m+vTp/P777/Tp04eVK1fSoEEDXn31VQYMGMDXX3/N5MmTqVKlCh9//DEZGRm0bt0agKeffpolS5YQHx+fZz/8Z599Rv369Rk/frz/L9zffvvNv27yu+++S0JCQrb9R48e5bzzzuPzzz8/4cNpyJAhrF+/nqNHj/o/nPv3789ll11G06ZNmTx5cr5dWKfaNfXYY48xatSoE9ZQKIimTZuyZMkSLrroIurUqcMll1xCr169cu2GKiqXXnopEydOJCYmhooVKxIVFcUXX3zh37927VoOHz5MdHTRl2MvdTIzYPmb8M0TJa7shBfcDjv9J/AgMAtoBRwGquGUorg/YNGFqCuuuMJf2/+mm26iU6dOTJ06lenTpxMdHe3vQunXrx933nkn27dvp3LlyixcuJBly5bRqlUrvv3224DGWK5cORo1apTnSmADBgygS5cuTJgwgYiICBISErj/fudHIb/kdKpWrlxJuXLlaNq0aaHvdZx55pm89tpr3H777bRt25bXXnstz+dmTW779u1j8+bN2bqNvLjvkpCQwLBhw/jhhx+oU6cOI0aM4IEHHvCvYfHoo48ydqz7PzjMKTqh7MR4OLNOsKMqUm6vEG4CLlHVgyKSoM7iNY+LSEIAY/NGAf5yLyo5l1U8duwYu3btIikpiXXr1mX7wKlXrx47d+7k+uuvJz09nXvuuYfdu3dz//3359qX7pUyZcrw9ddf57k/OjqaWrVqMXPmTBo0aECTJk0I5DLYI0eO5NVXX/WsvauuuooJEyagqicsR5pV1uSWmJjI448/7vnN99dff52ePXtSp47z4XP//fdTtWpVHnnkEVJSUqhWrRoXXnihp8c0WYRI2QkvuE0IqqoHj3+dZftpHsdTKuRcVrFcuXJUrVqVOnXqEB0dne0+wN69e6lYsSK7du3iuuuu48Ybb2T16tV07tyZhg0b0rFjx2CcAuBc3UyZMoWGDRsycOBA/3avu4wOHDjAxo0b/R/M+/btY8eOHcTFxXHdddedUmJcv349derUYd68ecyfP58rrriiwG14JS0tjXLl/u6bPv71/v37SUhIYM2aNf4/Eo7fL5o8eTJffvklp58eeiNdilQIlZ3wgtuOsV9F5F0RaQ+cLiLNRWQ8sC5woYWuuXPncuDAAQCmTJlCnz59KFOmDDfccAPLli1jy5YtgHPzOS4ujszMTF555RV/omjatCmVK1f2L2V4fNnKDRs2MHTo0FOK6XgbCQkJvPTSS2RkZNC5c2f/ury5ufHGG/nqq6/48ccfady4sX97fHy8f43j3P651bdvX7799lsiIyP55Zdf/K8fP348NWrUIDEx8ZSSQWZmJiNHjmTChAm8/PLLDBo0iP379xe4nVOVnp7O5Zdf7n9vO3fuzJw5c/w/E9OmTaN69eo0btyYRx99lGXLlvnPvVmzZgwfPpzExERLBoWRdhjmj4C3OsORPU7ZiT7vlOpkALhbQhM4A3gTOIIzGe0w8DpwhpvXB+Jf8+bNc10erjgv4zdq1CiNiorSW265Ra+88kqNjo7Wbt26aUpKiv858+fP1zZt2mhsbKx27NhRlyxZoqqqS5Ys0csvv1w7duyozZs31+HDh/tf89lnn+mFF16oLVq00AULFpxw3GuuuUbDw8P1kksu0WeffVanTJmi9erV06ioKB09erSqqr788svaqFEjbdWqlf7000965MgRrVmzpi5btizfc+rUqZO+8MILp/R+pKena2xsrD+W2NhY3bJli39/06ZN9dNPP832mlGjRvmXuIyNjfXHl5SUpLGxsf7lIGNjYzU1NfWEYyYnJ2vz5s21Tp06unr1an366ae1bNmy2qhRI129enW+8SYkJGhsbKyrc8svnpzvbXp6ug4fPlwvvfRSbdu2rbZt29b/fT9uy5YtGhsb618+c8iQIa7iKErF+Xcvm98SVcdf7CxnOfMe1SP7gh1RkcKrJTR9y1tWA1KAWqq6zeP85Jqth1A89OvXjxdeeIEaNWoEOxQTZMX+dy9n2YleL0P9E4cwh7pCL6EpIh+BcyNBVZN9WWbY8e0FCKSFiGwUkfgc2yuJyFsiskhE/isi80TEKrEWU3v27GHOnDns3r2btLQ0Swam+Mut7EQpTAYn4/ZD94SONVW9W0QWuz2QiFwDXAv8lcvu94HXVHWOryTGZxSP9Z5NLlJTUxkyZAhRUVFMnDgx2OEYk7eDyTB3KKz7AqKaQr8PQ3qmcWHlmxBE5HecUUU1RGRTjt3lcaqeurVCVT8XkcQcx2gOVFPfkpmqmglcXYB2TRGrWbMmf/zxR7DDMCZvqvDfD2DeQ3DsiFN2ou09IT/TuLBOdoUQDwjO8pb35th3APiv2wOpalIeuzoBm0XkZaA5sBt4SFULkmyMMcaxdwvMvhd+WwB1Wjv3CqrZPA438k0IqvotgIhcp6on1OMVkYbAz4WMoT7QG7hWVe8SkRuBBBE5V1UP5DjeYGAwQN26eS9cnZmZSVgpmWpuTHFQkMEpAVPKy054wW1xu19FJFJEokWkw/F/wHQPYggH/lDVL3zHmgakAVfmEsckdYrqRec1u/SMM85g27ZtpKWlFY8fUmNCnKqye/fuAhUq9Fzyz/DOFTBvGNRrA3cshZaDLBkUkNtaRlcBrwKVgZ046yDUBHZ4EMNeX5tZbQNqn0pjtWvXZteuXWzZsoX09PRCB2eMObmIiAhq1z6lX9nCyVZ2okKpLjvhBbejjIYCjYCZqtoRQEQuBm7xIIY1nHgTuRrw56k0FhYWRvXq1alevXohwzLGFGtWdsJzbq+nDvv68/0JRFX/BzT1IIYZQKSIxAGISEcgEpjtQdvGmFCTrezEXrjhQys74RG3VwiZInIusFVEXgLm45TBdj0jyTe8dBzQDBguIr1UtbeqHhCRK4EJIpIBpAPdVHVfAc7DGFMabPoWZt0NezdD84HQZRRE5F6i3RSc24QwGrgQGAZMAW4DNgCD3B5IVVcBcXnsWw60dtuWMaaUyVl2In6OzTQOALcJYamqHr9DG7x6y8aYEil5/1Hu/GA1r/S7lOqRBRyNtH42zHkADqU4k8viHgrJBe6LA7f3EP4T0CiMMSFtwjcbWLF5DxO+3uD+RQeT4eOb4aP+cEY1GPQNdHnCkkEAuap2KiKZZF8YJ6tknHsK96vqnjye47m8qp0aY4qPBo98SWp65gnbw8uG8cvobrm/KGfZidgHreyEh/Krduq2y+ghnKGg7wN7gKo4heq2AUuAG4GJwPWFjtYYEzIWPtiR0XPX85+1Ozh6LJOIcmFc0bgGI3rkUSbbyk4ElduE0FFVu2Z5vAVYJSJzVfVlYGVBKp8aY0qH6hUjiAwvS2p6JuFlw0hNzyQyvOyJ9xGs7ESx4DYh1BaRSqrqL10tImcB9bI8x+pEGGNOsOtgKv1b1aNfy7pMX/4HKQeOZn9C8s8w805IWgHnd4GeL8KZdYITbCnnNiFMB9aJyFxgF073UXecuQORwBt4U8bCGBNi3rjp7+7q0Vc3+XtHehosehEWPm9lJ4oJVwlBVZ8SkTVAH5yJZduBW1R1noiUAR7FSRTGGHNy21bBjDsheZ2VnShGXC9Tqapzgbm5bM8AfvMyKGNMiEo7DAljYOlEqFDDKTvRII/RRqbI2brFxpiiYWUnij1LCMaYwLKyEyWGJQRjTOBY2YkSxdUgXxE5oZNPRJ4VkVjvQzLGlHgHdsLHA6zsRAlTkAVyvsyxbRIwDatSaow5LmfZiU6PQZu7rexECZFvQhCRAb4va2T5+rjywJkFOZiItAA+AEar6uRc9o8CblbV+gVp1xhTDFjZiRLvZFcIA33/18zy9XEHgOFuDyQi1+DUP/orj/1ROOssHHPbpjGmGMjMgOWT4JsnrexECZdvQsiyfvJTqvpwIY+1QlU/F5HEPPY/CryGkxSMMSWBlZ0IKa5SeF7JwLecpiuqmpTXPhE5H6gFLHLbnjEmiNLTIPEZeKM97P7NKTvR/xNLBiVcnlcIIjICeE5V00RkQW5PAS4B7vEgjieAkUCV/J4kIoOBwQB169b14LDGmAKzshMhK78uowz+rmBaExibY7/grLFcKCISDRxT1R9FJC6/56rqJJzRTURHR1t1VWOKkpWdCHl5JgRVzZoA7lLVr3M+R0Ty7AYqgFHAvzxoxxgTKFZ2olRwW+30axG5EOiLc7WwHfgotyRREL7S2ecDk8UpeXsmzhDXRF/7rxWmfWNMIVnZiVLFVULwzUF4DWe5zN1AQ2C4iNyuqtNO9eCqegBokOU4ccBkVY071TaNMR6xshOljtuZyv8GGqvq5uMbRORcYAbObOWTEpHmwDic9RSGi0gvVe2dZf9jQG/+vkJ4UFWXu4zPGOOVAzvhy6GwbgZENYV+H0KtS4MdlSkCbhPCzqzJAEBVN4lIstsDqeoqIC6f/U/gjDYyxgSDlZ0o9dwmhI9E5DbgE1X9S0TOBK4HZgYsMmNM0bGyE4b85yFk8vew0+OLnL4hf693Kr79rienGWOKGSs7YbLI7wphGc5VQF4Ep1CdMaYksrITJof8EkJfVd2a34tF5DqP4zHGBFp6Gix6ERY+D6dVcMpOXNzXuUIwpVp+E9PyTQY+k4HLPYvGGBNYVnbC5MPtPISs9xOMMSWNlZ0wLrgdZZTzfsJZQHdgj+cRGWO8ZWUnjEtuE0JHVT2a5fEWYI2IzAZe9z4sY0yhWdkJU0BuE0J1yX7DKRxoglPCwhhT3FjZCXMK3CaEzTj3EI5nhWPAJuDBAMRkjDlVVnbCFILbhPCVql4R0EiMMafOyk4YD7hNCC+f7Aki0lNVZxcyHmNMQVnZCeMRtwnhWRE5i7+7jHIzHLCEYExRycyA5W/CN09Y2QnjCbcJYTfwDrAOZ6hpFeACYGmW59TwNjRjTJ6s7IQJALd/SvwIRKvqJaraUVUvBmKAH3yPO+JiXQQRaSEiG0UkPsu2+iLyjogsEJGlIvKBiNjUSWNyk54Gic/AG+1h929O2Yn+n1gyMJ5we4XQVFX/m3WDqq4RkQlZHt+dXwMicg1wLfBXjl3xwD5VvVycsa1TgUnANS5jM6Z0sLITJsDcJoQIEemLsx6CikgYcB1QvgDHWqGqn/tWQ8vqB2AtgK/tD4EPC9CuMaHNyk6YIuI2IQwBPgPeE5F9wJlAMs6Sl66oalIe23MushMB7HLbrjEhzcpOmCLkKiGo6koROQ/nvkFNYDuwRFWPBSCmnsCrAWjXmJLDyk6YIHB7hYDvw/87ERmgqt8FIhgRaQOcBwzKY/9gYDBA3bp1AxGCMcGXrezEvRA33MpOmCJxKgOW470OAkBE6gFjgT55XXmo6iRVjVbV6GrV7GaaCTEHdsLHA+Cj/nBGNRj0jdNFZMnAFBHXVwhZeL6skohUxRldFK+qO0WkLrBTVVO9PpYxxY6v7ETmlw+RnnqItHYPU6Hj/VZ2whS5U7lCmOxlACJSAfh/wGNAsu/x7Tj3KowJbXu3wLTe8MUQtpapQ7e0pxh7oLslAxMUoupuITTfUNM2QG0gCfheVTNdH0ikOTAOaAbsANapam8RGQM8nMtLzlHVzXm1Fx0drStXrnR7eGOKl8wMWD4JvnmSQ2kZPJ1+A+9ndEKz/I0WXjaMX0bb8FLjLRFZparRue1zu4Tm+cAsoB6wF2fFtM0icqWq/uamDVVdBcTlsn0EMMJNG8aEhBxlJ47EjWX/ogOEr93B0WOZRJQL44rGNRjRo1GwIzWlTEGqnY4GPlDVTN/VwvXAK4D9CWOMG+lpsOhFWPg8nFYBer8JTa+lqgiR4T+Smp5JeNkwUtMziQwvS/XIiGBHbEoZtwnhdFV9//gDX1fRdN8wUGPMySStcq4K8ig7setgKv1b1aNfy7pMX/4HKQeO5tOYMYHhNiGUE5HzsnYPici5BXi9MaWTy7ITb9z0d5fu6KubFGWExvi5/UB/ElgjIsuAFKAaEA30CVRgxpR4WctORN8CnR+3shOmWHNbumKeiFyCc9+gNvA/4Lb8RgEZU2od2Qf/eQRWT7WyE6ZEcTvK6AFVHQc8FeB4jCnZrOyEKcHcdhk9KCIXA4uAOar6ZwBjMqbkObATvhwK62ZAjabQ7yOo1SzYURlTIG4TwkvAs0B74H4RqQ1sAGap6vJABWdMsacKa6bD/Ifh2BHo9Bi0udtmGpsSye09hKcARGQxcBrQHbgDuBuwu2SmdNq7BWbdA5sSoG4M9HoZql4Q7KiMOWVu7yH8EycJXI6zFsJcnBXTvg1caMYUU1nKTiAC3Z+H6Fsh7FRKgxlTfLjtMmoPtALeA5630UWm1MpRdoKeL9oC9yZkuO0yulFEBGgN3Coi9XEK3M1R1UUBjM+Y4uF42YnvnoPwSH/ZCcTzavDGBI3bLqOBqvquiPwXiMIpTf1P4GagVgDjMyb4spWd6APdnoEzqgY7KmM857bL6HER6QvEAmuBOcAVqroiYJEZE2xphyDhqZOWnTAmVLhNCGHAJ8BAVd0RwHiMKR6s7IQphdwOi+ivqu9kTQYi0ltEqhfkYCLSQkQ2ikh8ju3NRGSJiCwWkVkiUqUg7RrjmSP7YMadMKUXSBmn7ETPFy0ZmFLBbUJ4PJdtpwOfuj2QiFwD3Af8lWP7acAM4GFVbQv8ALzutl1jPLN+Frzayplo1vZeGLLYahCZUiXfLiPfYvcAESJSB8g6pOIHCjYpbYWqfi4iiTm2dwMyVDXB9/gtnNXYqqlqSgHaN+bUWNkJY4CT30PYDBxfdHlLjn0HgFfdHkhVk/LY1QL4OcvztorIYeAyYL7b9o0pMCs7YUw2+SYEVQ0DEJG5qto9QDFEkaMbCdgHnHB/wrdC22CAunXr5txtjHtWdsKYE7idmBaoZOA/RC7bTpjxo6qTgEkA0dHRub3GmPz5y048ARJmZSeMyaI4LIGZDFyaY9uZvu3GeMfKThiTr+KQEFbgrMQGgO/mdXlgVdAiMqHFyk4Y40qe18kiMlhEri2CGL4EyopIrO/xLcBnNsLIeCJpFUyKhcSn4KKr4M4VcHFfSwbG5CK/jtMhwH8ARGRMbk8QkU5uDyQizX1DTpsBw0XkMwBVTQWuBsaKyCIgGrjdbbvG5CrtEMwfAW93diab3fAR9HnbahAZk4/8uowEiMAZARSTx3NGAN+4OZCqrgLi8ti3Op9jGFMwmxJh5t2wb4uVnTCmAPJLCG8DW0WkDICIZOTYL+Q+OsiY4DiyD/7zCKyeCpXPc8pO2ExjY1zLMyGo6ssiMgmoAXxIlhu/PgJ8EMDYjHFv/SyY8284lOKUnYgbDuVOD3ZUxpQoJ5uYlgpsEZG+qro1535fSWxjgsfKThjjGbcT07aKSFtgIFAbZ7W0d1T1+0AGZ0yerOyEMZ5zNT1TRAbgrIeQiTM/IBP4RERuDGBsxuRu7xaYeg3MuAOqN3KqkrZ/wJKBMYXkdmLa7UBTVd19fINvzYJZwLRABGbMCazshDEB5TYhHMuaDABUdbeIHAtATMacKPlnjn1+B+W2ryL1nM6EXzXeyk4Y4zG3CSFFRB4D3gFSgGpAPFZvyARalrITaVKeocfuoELkDYy2ZGCM59wmhDuA93FWTjs+9+Ar4KYAxGSMI2mVU4wueR0zMtow6tgA9lARlm9l2vKthJcN45fRtui9MV5xO8ooGegiIrVwRhltVdXtAY3MlF5phyDhKVg6ESrUYN/VU/nm5zocXrsDjmUSUS6MKxrXYESPRsGO1JiQUqBqp6r6J/BngGIxJpeyE6M4M6Iikb//SGp6JuFlw0hNzyQyvCzVIyOCHa0xIaU4lL82Bo7s9ZWdmJZr2YldB1Pp36oe/VrWZfryP0g5cDSIwRoTmkS1ZJYjio6O1pUrVwY7DOOF9bNgzgNwaBe0ucvKThgTQCKySlWjc9vn6gpBRDoA+1V1jZeBmVLuhLITH1vZCWOCyO2MnllAg0AGIiKNRCRBRBaJyGoRGRbI45kgUoXV78OrLeGXeU7ZiUEJlgyMCTK39xAWqupHOTeKSJyqJnoUy3vAV6o6wjcLeoOI/FdV53nUvikO9m6GWffCpgSoGwO9XoaqFwQ7KmMM7q8Q5orICBFpKiJ1j/8DnvIwlsbAEnBmQQMbgEs9bN8EU2YGLH0NJsY4i9z3GAfxcy0ZGFOMuL1CeMX3/5M5tnt5R3oOcCUwW0TOxUkQD3nYvgmW5PUw407YthIu+Af0fBEq1Q52VMaYHNwmhG9VtWPOjSIy38NYbgVmishvQGXgflVdkON4g4HBAHXr1vXw0CYg0tNg0Qvw3fMQHgm934KmfWyBe2OKKbcJ4R+5bVTVKzyM5TNgiap2FJE6wFcislJVf8hyvEnAJHCGnXp4bOO1LGUnaHotdB1rC9wbU8y5uoegqsdEpJ+IfCki80XkLBF5TkQ8mSoqIo2AzsB43/G24tRKGupF+6YIpR2CeQ/D252dNY5v+Aj+7y1LBsaUAG4XyHkM+BcwHzhLVfcC64A3PIrjNN//WctpHwMqetS+KQqbEp2bxktfheYD4V/LoEHXYEdljHHJ7SijzkAHVR0PHAJQ1XdxCt154WdgG3ADgIhEAr2ABfm9yBQTR/bCjH/BlKsgrKwzeqjnCxBh+dyYksTtPYQyqprh+1oBRCQMKO9FEKqaKiJXAy+IyA1ABeBz4CUv2jcBtG4mzP23U3ai3X0QO8zKThhTQrlNCItF5GucyWNnicj/Af2ABK8CUdWVQAev2jMBdmCnkwjWz7SyE8aECLcJ4WFgGPAoTjfRU8Bk4LnAhGWKLVVYMx3mPwTHjkKnkU5BOlvg3pgSz+0COenAGN8/U1plKzvRBnpNsJnGxoQQ1+shiEhn4HqgJrAd+EBVvwlUYKYYycyAZW/AgidBwpyyE81vgTC3YxKMMSWB22Gnw4Apvoc/AQJME5EHAxWYKSaS18Pb/3C6iOq3d4aStrjNkoExIcjtFcKNQGPf/AMAfBVJvwWeDURgJsis7IQxpY7bhJCUNRmAU5FURLYHICYTbEkrYeZdVnbCmFImz4TgK2993FwRGQ18AuzFKT53PWD3EEJJ2iFYMAaWToSKtZyhpBd6Wa7KGFOc5XeFsBlnElrWPoKHczxHgbEex2SCYVMizLwb9m2B6Fuh8+M209iYUia/hJBryeusRMSziWkmSI7shf88AqunQeXznLIT9dsGOypjTBDklxByLXmdg81LKMms7IQxJos8E4KqZq08ioi0BM7l78qkAMOBiwITmgmYnGUn+n8CNS8JdlTGmCBzNcpIRCYD3YBfgfQsu2oEICYTKKqw5n2Y/7CVnTDGnMDtsNNLgTqqmpZ1o4g86n1IJiD2boZZ9zg3j63shDEmF26nm35P9q6i45I9jMV4IHn/Ufq+sYTkA0edDZkZsGSis3BN0iqn7ET8HEsGxpgTuL1CGAssEJEtwIEs27vi3appiMhtwECc4awVgbtU9Vuv2i8NJnyzgRWb9zDh6w2MblsWZtwJ21bCBVc4i9ZU8mpNI2NMqHGbED7CWdHsZ7LfQ0j1KhARuRbohLMyW4aIDMTuUbjW4JEvSU3PBKAc6VRZ+SJpa77gIOWp/H9WdsIYc3JuE0K6ql6Tc6OI/OBhLI8BfY+vzOZbotO4tPDBjoyeu54daxfyhEyiYdhWVlbsTL3+L0GUXRUYY07O7T2EL0SkRS7bu3sRhIhUBxoBzUQkQUQWisg/vWi7tKgekUHfXa/xYdhjVJJD3HJsKF+c8zjVLBkYY1xye4XwL2C0iBzg73sIAkQBQzyIo76vvWuAzkB1YLmI/KWqHx5/kogMBgYD1K1bN5dmSqnfEmDWPbTbt4VlVa+h0pVjqLVmLynHbywbY4wLbhPCPiA+xzYBXvQojnCcq5WXfV1G20VkKnAL4E8IqjoJmAQQHR2tHh275Mql7EQrX9mJ0fXPDnJwxpiSxm1CGKyqK3JuFJF+HsVxvLT2zizbkoCrPWo/9FjZCWOMx1zdQ8gtGfjc7lEcG4DDOF1Fx1UD/vSo/dBxYCd8dBN8fBNUiILBCU5lUksGxphCclu6YkEeu5oB9xQ2CFVNFZEpwK3AIhE5A7gOeLqwbYeMnGUnOj8OMXda2QljjGfcdhnVJPu6B2cCVwAvexjLv4HXRWQVzlyHycA0D9svufb8DrPvtbITxpiAcpsQBqrq0qwbRORlstzwLSxVPQTc5FV7ISEzA5a9AQueBCkDPV6A5gNtgXtjTEC4Sgg5k4FPZeBib8MxfsnrreyEMaZIub2HsCnHpnCgKjDO84hKu/Q0WPQCfPe8s4Rlbys7YYwpGm67jP4C7s3yOA3Yoqo2CshLSSudq4KU9dD0Wug6Fs6oGuyojDGlhNuE0E9V1wc0ktIs7RAsGANLJ0LFWtDvY7jwimBHZYwpZfJMCCLy+fGCdpYMAshXdoJ9WyD6Vmc4aUTFYEdljCmF8rtCiPPNPxCc9QnwfU2Wx6qqnQIVXEjLpewEvrITxhgTDPklhDWqennOjSJyHvA2TnVSr2Yqly5WdsIYUwzllxAG5NwgIvcBTwJzgD6quitQgYWkAzucRLB+FtS4GPp/AjUvCXZUxhgD5JMQVHXr8a9FpCHwLnAecIuqflwEsYUOKzthjCkB8h1lJCJhwHDgUeBL4CpVTS6KwEKGlZ0wxpQQ+Y0yuhh4B2fxmltU9YNcnvOIqo4OXHglmJWdMMaUMPldIazEGVX0NnCBiDyWY78ANwOWEHKyshPGmBIov4Swluyzk3NztWeRhAIrO2GMKcHySwijVPXb/F4sIqM8jqfksrITxpgSLr9RRl+c7MVunhPyrOyEMSZEuK1lVCRE5AJgHdBFVRODHM7JWdkJY0wIKVYJAXgCp5Jq8WZlJ4wxIajYJAQRaQEcBFKCHUu+rOyEMSZEFZuEAIwCBgNdgh1IrqzshDEmxBWLhCAi3YC1qpok+QzRFJHBOEmDunXrFk1wVnbCGFNKBD0h+MpjDAN6n+y5qjoJmAQQHR2tJ3l64VnZCWNMKRL0hAD0A+ar6p5gB+KXmQHLXocFo63shDGm1CgOCaE90EREjg/erwGMF5EtqnpVkUezcx3MvMvKThhjSp2gJwRV/WfWxyKyGbi3yOchWNkJY0wpF/SEcJyItASe5e8rhM9U9YkiObiVnTDGmOKTEFR1ORBXpAe1shPGGONXbBJCUUref5Q3Jr/NwxmvU+avP6zshDHGUBoTwpF9bJ18B4/umcOu02pT1cpOGGMMUMoSQoNHviQyfS9fhi9kYkYvXjram9TX9xFe9kt+Gd0t2OEZY0xQlaqEsPDBjoyeu56ua19id3o4EeXCuKpxDUb0aBTs0IwxJuhK1Uyr6hUjiAwvy570cMLLhpGanklkeFmqR0YEOzRjjAm6UnWFALDrYCr9W9WjX8u6TF/+BykHjgY7JGOMKRZENfAlgQIhOjpaV65cGewwjDGmRBGRVaoandu+UtVlZIwxJm+WEIwxxgCWEIwxxvhYQjDGGANYQjDGGONjCcEYYwxQgoedikgKsCXYcbhUFdgV7CACKJTPz86t5Arl8yvMudVT1Wq57SixCaEkEZGVeY37DQWhfH52biVXKJ9foM7NuoyMMcYAlhCMMcb4WEIoGpOCHUCAhfL52bmVXKF8fgE5N7uHYIwxBrArBGOMMT6WEIwxxgCWEAJGRMqJyL0ikigi34rIEhHpFOy4vCYiF4jIMRGJC3YsXhOR20RksYgsEpH/iUhssGPygog0EpEE33mtFpFhwY6psESkhYhsFJH4HNub+X73FovILBGpEqQQT1lu5yYi9UXkHRFZICJLReQDEcl1bkFBWEIInLOBe4CrVDUWeAyYISJnBzcszz0BpAU7CK+JyLVAJ6CDqrYDXgRqBDcqz7wHfO87r87AMBHpGuSYTpmIXAPcB/yVY/tpwAzgYVVtC/wAvF70EZ66vM4NiAf2qerlQAyQgQc3mi0hBM4B4DFV/QtAVb8CjgJtghqVh0SkBXAQSAl2LAHwGPCEqmYAqOq7qvpRkGPySmNgCYCq7gY2AJcGNaLCWaGq/XB+57LqBmSoaoLv8VtAby/+ki5CeZ3bD8CrAOqMDPoQ6FLYg1lCCBBV3a2qU48/FhEBTiO0PjxH+f6FFBGpDjQCmvm6VhaKyD+DHZeH5gBXAojIuTgJYllQIyoEVU3KY1cL4Ocsz9sKHAYuK4q4vJDXuanqTFX9LcumCDwo01Hq1lQOolic2kvfBTsQL4hIN2CtqiY5uS6k1AcEuAanS6U6sFxE/lLVD4MZmEduBWaKyG9AZeB+VV0Q5JgCIYoTu1r24Xw/Q01PfFcMhWFXCEVARCKAp4B4Vc0MdjyFJSJhwDDg6WDHEiDhOL8bL6tqhqpuB6YCtwQ3LM98BixR1fOAi4H7RaTE/NVcQLlNtAqpv2BEpA1wHjC+sG1ZQggwX1fRJOBFVV0V7Hg80g+Yr6p7gh1IgOz1/b8zy7YkoHYQYvGUiDTCueoZD/5ulK+AoUEMK1CSgTNzbDvTtz0kiEg9YCzQR1WPFbY9SwiBNw5YrqqfiEi4iNQNdkAeaA/09A2pTcQZfTNeRGYENyzPbMDpa87atVAN+DM44XjqNN//WT88jgEVgxBLoK0AGhx/ICJ1gPJASPxhJiJVca5c41V1p4jUFZHwwrRpCSGAfOO7ywKTRaQCzmVdie92UNV/qmpbVY1T1ThgB3Cvql4V5NA8oaqpwBScvnZE5AzgOpzhmiXdz8A24AYAEYkEegGheA/hS6BslvkjtwCfqWqJH9jh+zz5fzij4ZJ9j28HahaqXatlFBgiciHwSy67Rqnq40UcTkCISEvgWaA1zgfNZ6r6RHCj8oYvCbwOXASk4/zyPach8AsjItHACzh96RWAr4GHVDU9qIGdIhFpjnMl3gznj5N1qtrbt+9SYCLOOP29OH9N7w5SqAWW17mJyBjg4Vxeco6qbj7l44XAz7cxxhgPWJeRMcYYwBKCMcYYH0sIxhhjAEsIxhhjfCwhGGOMASwhGGOM8bGEYEyAiMjLIrIv56ItxhRXlhCMCRBVvQtYE+w4jHHLEoIxxhjA1kMwxlO+shCv46yOt4IQK7VsQptdIRjjEd8avp8D43zrFb8HtApuVMa4ZwnBGO/E4JTM/hhAVdcAvwYzIGMKwhKCMd6pCexT1Yws20J1ESETgiwhGOOd7cCZIpL13lyVYAVjTEFZQjDGO0twlme8DkBEmgGNghmQMQVh6yEY4yERacHfo4zW4iywUxV4UFVnBjM2Y07GEoIxxhjAuoyMMcb4WEIwxhgDWEIwxhjjYwnBGGMMYAnBGGOMjyUEY4wxgCUEY4wxPpYQjDHGAPD/Af6rJXzSSj2NAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEQCAYAAABBQVgLAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAA+dklEQVR4nO3dd3hU1dbA4d+iJSolSleqBQQsCKGXhN4UBQFpXqMoiteCWK8iWBC7F1FBsUX0YsEPlI6UUFS6eK8KKlIEpCR0AQkkWd8fZzJOJpPkBGYyKet9njxh9jlzzpohyZpz9t5ri6pijDHGZKdYuAMwxhiT/1myMMYYkyNLFsYYY3JkycIYY0yOLFkYY4zJkSULY4wxOcrTZCEiTUTkNxGJy2L7kyKyza9NRORFEVkjIutE5Ma8iNUYY8zfSuTViUSkF9AXOJzF9srArcApv023A42BZsB5wE8i8l9V/V8IwzXGGOMjL68s1qjqQODPLLY/DkwM0H47EK+qaaq6D5gF3BaiGI0xxgSQZ1cWqrozq20icjFwPvA5ztVFensEcAXws8/uG4A+OZ2vQoUKWqtWrdMN1xhjiqR169btU9WK/u15lixy8BQwGijv114B5+rH99bVIaBSTgesVasWa9euDVZ8xhhTJIjI74Hawz4aSkSigVOq+kM2u/kXsJIsjjVURNaKyNqkpKSgxWiMMUVd2JMF8CTOVUUg+4A0IMqnLQpIDLSzqk5S1WhVja5YMdNVlDHGmNMU1ttQIlIGuBiIFxFwEkEVEVkCfKqqE0XkB6AusNrztPrAmryP1hhjiq6wJgtV/RMnEQAgIrE4I59ifXZ7E4gTkY9whs72ALrkXZTGGGPycp5FY+BloCHwiIj0VNXePttHAb35+8riIVVdDbwFXIRzZVEMeFBV/3u6caSlpbFz506OHTt22q/FGOPeOeecQ7Vq1ShWLD/c9TanSwrr4kfR0dEaaDRUYmIiycnJXHDBBfbDa0yIpaWl8ccffxAREUGlSjkOYjT5gIisU9Vo//Yi99fy0KFDVK5c2RKFMXmgWLFiVK5cmcOHAxZuMCGQeOQE/d5aQeKfJ4J63CL3FzM1NZWSJUuGOwxjioySJUuSkpIS7jCKhuMH+G3yP/l5207GL9wU1EPnl0l5ecoz8soYkwfs9y0PqDJ81ChGFounCcdoIjX5aNXZfLRqOxElivHLmG5nfIoid2WR33377bd06tSJtm3b0rJlS2644Qa2bt0a7rAymTRpErVq1SIuLi7Lfa644gp+++23vAsqBLp3786SJUuCdjw375tbX3/9NZ07dz7zoMJ0fBMkR3bBJwMZV3w8x86qyvVpY1mU1pjIksW4tuH5LH+4XVBOUySvLPKrJUuWcPPNNzN//nzq1KkDwLRp02jdujVr1qzh/PPPD3OEfxs6dCi7du1i27ZtWe6zbNkyoqKiANi2bRu1a9cmVAMq4uLiqFWrFk888URQj/vJJ59QpkyZoB3PzfvmVqtWrZg6deqZB+Xy+E888QTbtm0jPj4+ZOc0uZCWBt99AAtGQeop6DyGd/a05oc1u4goUYzklDTKRJSgUpnIoJzOrizyibS0NIYOHcqjjz7qTRQAvXv3pnXr1jz66KNhjO70pCeKgqxs2bL59jaKiFCuXLkCe3xzBvZvhsk9YdZwqHol3PkttLybxGOpDGpWk+l3tmJQs5okHU0O2iktWeRSqEYarF+/nk2bNtGpU6dM27p27coXX3xBWload955J1FRUTz++OP07duXOnXqZEokL774Is2bN6dNmzbcfffdnDx5Msvzjh07lgYNGtC5c2eee+45RITY2Fi++uorLr30UmJjYwGYPn16wNsnf/31FzfddBMtWrSgTZs23ltm999/P1FRUcTHx3P48GH69+8PQGxsLLGxsaSmpmaKJSkpie7du9O0aVN69erFrbfeSpUqVXjqqacAeOqpp2jfvj3t27fn6quvZteuXQC8+uqrzJs3j/j4eGJjY3n33XcBWLduHW3btiUmJoYOHTrw889O8eK0tDSGDRtG69atadu2LbfeemvAeTcvvvgiVapU8V6tuHnv023fvp3mzZsjIsTHx9O5c2ciIiK8VxRZvW+BLFiwgFatWtGuXTvatm3L1KlTSUpK8h4fYPXq1TRs2JBatWrx4osvEhsb6x3xt3nzZrp160ZMTAwtWrRg9Ginuk7nzp0REbZt28Zff/2V4Xj+x//000+Jj49n3rx5xMbG8swzz7h+H00QpabAN+NhYkvY/V+4ZjzcNBPOuxCAt26MZsx1l1H//LKMue4y3rox0wjY06eqhfKrcePGGsiGDRsCtrv12LT/aa1HZulj0/53Rsfx98knnyigJ0+ezLRt/vz5CujevXtVVTUmJka7d++uaWlpumvXLi1RooT+8ccfqqr60Ucf6aWXXqrHjh3TtLQ07du3rz799NMBzzl79mytUqWK7t+/X1VVR4wYoc6PhOP999/XmJgY7+PRo0frTTfdlOFx+fLlddeuXaqq+swzz2iLFi2822NiYvT9999XVdWtW7dmOHYgffv21aFDh6qq6uHDh7V27doZzjd+/HhNS0vzxjZ48GDvtptuuklHjx7tfXzo0CGtUKGCLlq0SFVVZ82apXXq1NHU1FSdPXu2du3a1bvvddddp1u3bg0Yk/9xs3vv/aW/5g8++EBVVV9++WXdtWtXju+bry1btmiZMmX0119/VVXV1atXa2xsbIbjp0tISNCSJUvqggULVFX1gQce0JSUFK1Xr57Gx8d735cLLrjA+xzA+9r9j+f/2P//Pzfv45n+3hlV3f0/1Tfbqo4uqzplgOrhwD93ZwpYqwH+ptqVhUt1R86l1iOz+WjVdlTho1XbqfXIbOqOnBuWeLp06YKIULVqVcqXL+/9xBofH0///v05++yzEREGDBjAhx9+GPAYU6dOpXv37px33nkADBo0KNdxtGrViqpVqwJw4403smLFCrZv357r46SmpjJ9+nQGDx4MOLd/rr766gz7VK9e3fvpety4caxbty7L482aNYvSpUvTvn17AHr06MGePXtYtWoV5557Lj/88AMLFiwgLS2Njz/+mBo1ariONav3PivXXnstACNGjPC+V27ftylTphAdHc0ll1wCQJMmTRgzZkyW5zrnnHPo2LEj4FwZrVy5kt9++837f1uuXDk+/fRT1681O2f6PhqXUpJh8RiYFAtH/oC+8dD/P1A2b/swLVm4tPyhdvRseD6RJZ23LNgjDS666CIA760VX3/88QdRUVFUqFDB21a2bFnvvyMjI723mnbu3MmUKVO8t3uef/557+2I/v37e9v37NnD7t27MxwzPWnkxrnnnuv9d/nyznIku3fvzvVxkpKSSElJyTKeTZs20a9fP1588UWWLVvGuHHjOH78eJbH27lzJwcOHPC+3tjYWCpWrMj+/ftp0aIFkyZN4vnnn6dmzZq89NJLuep4z+q9z0qg+/5u37edO3fiX0G5VatWrs+1c+dOzj33XEqU+HssS3bPz40zfR+NC9tXwputYdmLcHk/+OdqaNALwtCPZqOhXKpUNpIyESVITkkLyUiDRo0acfHFF7NgwQJuvfXWDNvmz59Pnz59XM06r169Op06deLBBx/0tu3btw9wRvb4qlq1Kr7rfuzfvz/D9lKlSpGc/HcH2aFDhzKd78CBA5nOk/6JOTcqVqxIiRIlSEpKol69epniWb9+PWXLlqVJkyYAnDrlv1R7RtWrV6datWoZhr0eOXKEyMhIDh8+TGxsLN27d2fz5s107dqVCy64gJtvvjnXcZ8ut+9b9erV+eWXXzK0rVu3jsaNG7s6T/Xq1Tl48CApKSnehLFx40Zq1arFWWedRcmSJb3/x4H+f7OTH97HQiv5KCx6ClZPgnLVYPD/wcUdwxqSXVnkwr6jyaEbaVCsGG+//TZjx45l06a/Z15++eWXrFy5MttbD77i4uKYOnUqJ044HfAJCQncfvvtAfft168fc+bM8f5R/uyzzzJsr127Nps2bSI5OZkTJ06QkJCQ6RjLli3zfiKePHkyLVq0CHgrIn346fHjx3nuuedYuXJlhu3Fixend+/e3ltmR44cYd68ed7tF198MQcPHuTXX38FyLAt/fjHjx/n2LFjDBo0iKuvvpp9+/axZo1Tzf7YsWO0a9eOw4cPM336dCZNmgQ4V3TVqlUL2OEeSm7ftwEDBrB27VrvfJVvvvnG9c8CQLNmzbj44ouZMmUK4CSpfv36eRNH7dq1+fHHHwGYM2dOtsdKf49VlV69euWL97FQ2rQQJjR3EkWz2+HOlWFPFIB1cOc3y5Yt0/bt22ubNm20RYsW2r9/f92+fbt3+4MPPqjlypXTunXr6rfffqvDhg3TiIgIvfLKK/Wnn35SVdWXXnpJmzZtqu3atdNrr73W2zEeyDPPPKP16tXTLl266Pjx4zN1Qg8ePFjr16+vgwYN0rvuuksrV66sY8aM0bfeektr1qyp1113nfbr10+bNWumrVu31s2bN6uq01meHuesWbNUVXXgwIHauHFj7dixox4/fjxTLImJidqtWzeNjo7WPn366LBhwzQuLs67feTIkVqzZk3t2bOnDh06VCMiIvTGG29UVdVvv/1W69atq02aNNH//Oc/qqq6du1ajYmJ0bZt22qbNm105syZqqr6888/a/fu3bVdu3bapEkTHTJkiCYnJ2eK54UXXtDKlStrzZo19Z133nH13qfbv3+/NmvWTAGNiYnxbs/pfQtk/vz52rJlS42NjdVu3brpjh07NDExMcPxf/zxR73yyis1IiJCY2JivIMWVFV/++037dq1q7Zt21Zbt26tS5Ys8W77/PPP9cILL9Ru3brpG2+84T3enj17Mhw/JSVFN23apPXr19fmzZvrCy+84Pp9VM3/v3f5wrH9qtNudzqwX4tW/X1lWMIgiw7uIld1duPGjd7bHCajUE+cy8mhQ4coW7as93bbP//5T0qXLs3zzz8flnhM8NjvXTZU4afpMPch+OsgtB4BbR+AEhFhCceqzpp876WXXmLBggWAkzhmzZpFly62zpUpxI7shk8Gwec3O30TQ5dC+8fCliiyY8nCAM6IK9+JczmN8AmFmJgYRo8eTWxsLB06dGDEiBHeoa/GFCqqsC4e3mgGmxdD5zEwZCFUuSzckWXJRkMZAC644IJMnc55rVOnTgFnsBtTqOzfDDPvhW3LoVYbuOZVKH9RuKPKkSULY4zJC6kpsHICJIyF4iWdJNHoprDMmTgdliyMMSbU9vwIM+6CXeuhbnfo8XKez8A+U5YsjDEmVFKSndnXX/8bzjoX+rwfthnYZ8qShTHGhML2VTDjbtj3C1w5ALqMhbNzX1Inv3CVLESkDtAcmAKUA14CigOPqurO0IVnjDEFTD4s1REMbofOvoyTJBR4zvPv34B3QhRXkfPUU09lWDshLy1btoxGjRrRtGlT4uLiuOOOO5g8eXKex+Fvz549dO7cOeASpAcOHKBnz560bt2a5s2b891332V5nPj4eNq3b0+7du2Ijo7OVCMrHDZt2kTjxo0z/X8nJSVx3333ERsbS6tWrejevTtbtmzJ9lgzZsygbdu2tG3blgYNGmQq22Ly0G8LYUILJ1E0HQp3rigUiQJwV+4DWOD5fhawByjjebzUzfPD8VUQy334r50QDL5rSmSldevW3hIZEyZM0D///FNPnTrl3V6zZk1NSEgIalw52bx5s3bs2FH79++fYQ2FdDfccIOOGjVKVVUXL16s1apV0xMnTgQ8VtmyZb0lU3788UeNjIzUdevWhSz2nKxYsUJ79OihnTt3zvT//f777+v111+vqampqqr66KOPasOGDbM81rfffqsdOnTQY8eOqapTGuTll18OWeynKz//3gVFPinVEQyc4XoWpUWkBDDQkzj+9LTnqpdGRJqIyG8iEufTVktE3hORxSKyUkQ+FpGKfs+7X0TWeb4ezHRgc0Z27tzpXd972LBhlC5dOkNJ63AoW7YsM2fOpG7dupm2HThwgKlTpzJkyBAA2rVrR6lSpZg1a1bAYz3xxBNUr14dgAYNGtCgQQMWLVoU1HiXLFniXVUwJzVr1uTLL78MWGW2Tp06PPTQQ96SJwMGDOD777/PUB3Y19ixY7n//vs5++yzAWf1uxEjRpzeizC5l16q442m8MNUaPsg3L4cajQLd2RB5zZZvI9zRfEsMFZEyovINOCX7J/2NxHpBdwHHPbbFAccUtX2QAsgFZjk87yuwG1AK8/XEBHp4fa8BU1iYiJ9+vShadOm9OjRw1u+GpxS5S1atCAmJoZrrrnGu/bF8ePH6devHzExMbRu3Zr77rsPgH/96198//33PPfcc8TGxjJ79uxM5+vduze7d+9m+PDhdOvWjQ8//DDD8qk333wze/bsYfjw4cTGxma74BDAxIkTKVOmDPXq1ePrr78mKSmJRo0aUbt2bX744QfX70OFChWIjAxc/v27774jIiIiQ5XW+vXrE6gWGOB9P9KdOHEi0xoRAD/88AP16tUjIiKC119/nRkzZlCpUiViYmJcx+1G1apVKV68eMBtLVu2pGnTphlijYyMpHTp0pn2VVUSEhLYvXs3nTp1onXr1t7lTk0eSC/VMTUOyl7gKdUxEkoGZ9mC/MbVx0dVnSQi/wFSVfWE5yrjPiDwx53A1qjqdBFZ4tf+HfCT5zwqIp8AvjeVbwemqOoJAE8cdwCZ//IVAosXL2bNmjWUKVOGoUOHcs899zBlyhS2bt1Knz59WLt2LXXr1uWNN97gH//4BwsXLiQ+Pp7y5cvz2WefkZqaSvPmzQF49tlnWbFiBXFxcQHv+wNMmzaNWrVqMW7cOO8n482bN3tXf3v//fdJSEjIsP3EiRNcdNFFTJ8+PcMfNnCuTDZu3MiJEydo3bo14KzA16hRIy6//HLi4+OJj4/P8vX7rj+Rlb1792Za5CcqKorExMQcn7tlyxb279/P9ddfn2nb5ZdfzooVK6hfvz7Vq1fnyiuvpGfPnrzzTvi65mbNmsUtt9zCWWedlWlbUlISx44d44MPPmDu3LmkpqYSExND8eLFeeSRR8IQbRGhCt9Nhq8eh9Rk6PQ0NL8TihfuwaW5eXXlgQEicg5OJ/dlqur6D7ZmMWpKVWf4NUUC+3weNwE+9nm8AbjT7XlzNPcR2OP+E+9pqXI5dHvO1a5dunTxrv1w44030qFDBz788EPv8prpt2UGDhzIXXfdxe7duznvvPNYvnw5q1atolmzZixdujRkLwWgZMmS1KtXL+AKcAD/+Mc/6NSpE+PHjycyMpKEhATvrZHsElduSIBx6ppDtVxV5d5772XSpEne99hfVFQUEydO5I477qBVq1ZMnDgxy+P5Jr5Dhw6xbdu2DLei3CS+7GzevJkZM2YEXEcE8C5adOutt3pvQ91xxx289NJLlixCpYCW6ggGt0NnrwXeBb4GLgTGAH1E5HJVdfdX0L2rgTd8Hlcm462rQ0ClIJ8z3/BfbvPUqVPs27ePnTt3smHDhgx/jGrWrMnevXvp378/KSkp3Hvvvezfv58RI0YwbNiwkMVYvHhxFi5cmOX26Ohozj//fGbMmEHdunW57LLLAv5xP12VKlXi8OGMdzMPHTpEgwYNsn3eY489Rrt27bjmmmuy3e/aa69l/PjxqGrA21XpfBPfkiVLeOKJJ844QaQ7ePAgQ4YM4eOPP84yKUdFRQFQuXJlb1u1atXYudNGswddagqsmgiLnymQpTqCwe2VxYM4VxJ7RCRBVU8CN4vIUpyrjKAQkZbARTh9FL5cLbAgIkOBoYD7heNdfuLPK/7LbZYsWZIKFSpQvXp1oqOjM/Q7HDx4kLJly7Jv3z5uuOEGBg8ezPr16+nYsSOXXnop7doFZ33w03HjjTcyefJkLr300gzLbAbjNlSjRo04ceIEO3bs8HZcb9iwIdsrlvHjx3Pq1CnvFc6mTZu45JJLAu67ceNGqlevzrx585g/f36el0n/66+/uOGGG3jhhReoW7cuiYmJREREZEoaZcqU4aKLLspw+y0pKck7WMEESSEo1REMbju4U1V1TygDEZGaOImnj6r6LrCcCET5PI4ii74SVZ2kqtGqGp3dJ8L8bM6cOfz5pzPYbPLkyfTp04fixYszYMAAVq1axe+//w44HeGxsbGkpaXx+uuve5PI5Zdfznnnnedd3jJ9KcxNmzZlWJc7N9KPkZCQwKuvvkpqaiodO3bMtDa0r8GDB7NgwQJ++OGHDJ/44+LiWLJkSZZfbpQvX56+ffvy3nvvAbB06VJOnjxJjx7OuIfFixd7y62Ds/b40qVLGTVqFEePHuXo0aM888wzAY+dlpbG6NGjGT9+PK+99hq33XYbR44ccRVXMKSmpjJgwACGDBlC/fr1OXr0KNOnT2f9+vVA5td22223ER8fT2pqKikpKUyePJmbbropz+It1FKSnSuJSTFwaIdTqqP/lCKZKADX8yz+DxgNVAcSgPNwOrinunm+37GWAHF+bRWAZcCFnsc1gAjPv78AHvfZ93FgZk7nKWjzLJ588kmtXLmy3nLLLXrNNddodHS0duvWTZOSkrz7pC+vGRMTo+3atdMVK1aoqjNuv3379tquXTtt3LixPvLII97nTJs2TevUqaNNmjTRxYsXZzpvr169vEuDvvDCCzp58mStWbOmd/lUVdXXXntN69Wrp82aNdMff/xR//rrL61ataquWrUq29fUoUMHfeWVV07r/UhJSdGYmBhvLDExMfr77797t+/fv1+vueYabdWqlTZv3jzDvInPPvvMOzfh6NGjWqpUKcW5OvV+BZq7kZiYqI0bN9bq1avr+vXr9dlnn9USJUpovXr1dP369dnGm5CQoDExMa5e286dOzUmJsa7ZGtMTIx3OdJJkyZlihXwznPxfW3p79Pw4cP1yiuv1ObNm+sDDzygJ0+edBVHXsqvv3dZ+n2l6mtNnHkT02535lEUEWQxz8LtH/iKwFdAmucrFZgHVHTzfL9jZUgWQGlgKRDr+XdpYCxQy7O9K06ndqTnayPQI6fzFLRkURgNGDBAd+/eHe4wTD5QYH7vTvypOuch1dHlVF9poPrrgnBHlOeyShZuh84mAZ1F5HygGrAD2Kuqrgd0i0hjnLIhDYFHRKSnqvYG/gW0xbli8TXJc+55ItIA+MbT/p7mYhSWyVsHDhxgxYoVNG/enJMnT1KlSpVwh2SMO78tgpnD4fAOaHobdBgFEYFHzRVFbkdDvaqq96rqLmCXp+1zEdmhqvfl8HQAVHUdztWDf/tjwGM5PPdlnERj8rnk5GSGDRtG5cqVmTBhQrjDMSZnxw/A/Mfgv1OgQh24ZX6hnIF9ptyOhrrcv0FV+4jI8iDHYwq4qlWrsn379nCHYUzOVGHDFzDnQfjroFOqo80DhXYG9pnKNlmISAJOB1tDEVnst/nsnJ5vjDH50pHdMOcB+HkWVG0IN053Js+aLOX0xz7e870q8IHftj8B/wRijDH5VxEt1REM2b5DqvoBgIhsVdVl/ttFJCpEcYWUqgZ1RrExJmuaQxmWPHNgi1OqY+uyIleqIxjcjoZaBiAiFXBuP6X7BGgZgrhCJjIykv3791O+fHlLGMaEmKqyf//+LCsI54m0VFg5IWOpjqv+AcXczkk24H40VEucYn7VyLiGRT75yOBeeu2crNYHMMYEV2RkJNWqVQvPyff+BF/eBbu+K9KlOoLB7Y26sThzIeJVtZ2IlMSZLNckZJGFSMmSJaldu3a4wzDGhFJKMix7Cb5+BSKjnFIdDXoVqcJ/weY2WZxU1d9FpDiAOrWbZopI8EqFG2NMMOxY7VxN7PsFrugPXZ+Fs88Ld1QFnttkUczTmX1ARO4D5gPNgMBlO40xJq8lH4XFT8Oqt6BcNRj0f3BJx3BHVWi4TRavA92BkcAMnNnUB4Gbs3uSMcbkCSvVEXJuR0N94fPwQhGpCOzPTW0oY4wJukylOuZBjebhjqpQcjsa6nNV7ZP+2FNY0BhjwkMVNnzpzML+66BTpqPtg1aqI4Tc3obqISJbArQrzuJE84FnVTU5aJEZY4qMxCMnuOvj9bw+8CoqlcnhD76V6ggLt8nieaA+zlyLA0B5oC+wHtgCDATGAaFb+NkYU2iNX7SJNdsOMH7hJsb0yuIPvyqs/xDmj/SU6ngKmv/TSnXkEXEzFV9E5qhqd782wVmx7moRKQZ8o6otQhRnrkVHR+vatWvDHYYxJht1R84lOSVz12dEiWL8Mqbb3w2+pTpqtoae461UR4iIyDpVjfZvdzvfvZpnIp6vUkBNAE9Ht92CMsbkyvKH2tGz4flElnT+FEWWLMa1Dc9n+cPtnB3SUuHb12FCS9j1PVw9Dm6aaYkiDNxevy0GVovI58A+nGVW+wALRSQSGAWcCE2IxpjCqlLZSMpElCA5JY2IEsVITkmjTEQJp99i708w4274Yx3U6QZXv2KlOsLIbbIYAdyBkyCqAruBN4G3PcdYBLwVigCNMYXbvqPJDGpWk4FNazBl9XYOHjkCCWNh+cueUh3vQYPeVqojzFz1WRRE1mdhTAFkpTrCLqs+CxtGYIwJv+SjsHgMrHoTyl4Agz6HSzqFOyrjw5KFMSa8Ni92RjodslId+ZklC2NMeBw/AF+NhO//A+UvgZvnQs18M/re+HFb7uMqVV3v13Y3sFBVN4YkMmNM4bXhS5j9APx1wEp1FBBuryxeBtr7tf0AvEsBW1bVGBNGf+6B2fd7SnVcCYP/D6peEe6ojAvZJgsRaev5Z5SItCHjkqpnAeVyczIRaYJTMmSMqsb7tDcEJgJpOOVE4lR1v2ebAC8AsTiTCMep6oe5Oa8xJsysVEeBl9P/1Aee71WAyX7bjgAT3J5IRHrh1JM67NdeCvgSJ0EkiMiTOHM4+np2uR1ojLPY0nnATyLyX1X9n9tzG2PC6MBWmHmPleoo4LJNFqpaG0BE3lPVW87wXGtUdbqILPFr7wakqmqC5/E7wDYRqegphX478G9PSZF9IjILuA24+wzjMcaEUloqrJzoDIktXhKu/jc0ioNibqsMmfzE1f9aVolCRP7l9kSqujOLTU2An3322wEcBxqJSARwhe92YAOQacKIMSYf2bsB3u0EXz0GF8bAnSsh+hZLFAVYllcWIjIYmKKqaSLyXha7dQWePcMYKuN3awo4BFQCKuAktMMBthlj8puUZKdMx/JXILIcXP8uXHa9leooBLK7DdUKmIbzKb8dEB9gn2BVmg1Uc0Sy2R7wJ09EhgJDAWrUqBGcyIwx7uxYAzPugqSf4YoboMuzcE75cEdlgiTLZKGqvgsZPa6qH/nvIyKbgxBDInCVX1uUp30fzgipqADbMlHVScAkcGpDBSE2Y0xOrFRHkeBq3JqqfiQi5wI9+Lvq7OxACeQ0rAH6pz8QkerA2cA6VU0WkR+AusBqzy71Pc8xxoSbt1THdmhyG3QcbaU6CilXvU0i0hn4HXgCp0z5kzgjloLx8WEuUEJEYjyPbwGmeUZCgTOMNk4c5XES1jtBOK8x5nQdPwBf3Akf9oLiEXDzPOjxkiWKQsztjJgXgC6quiK9QURaA28AV7o5gIg0xpkJ3hB4RER6qmpvz9XDdcAEEUkFDgJxPk99C7gI58qiGPCgqv7XZdzGmGBLL9VxfD+0uR/aPmSlOooAt8nioG+iAFDVr0XkkNsTqeo6nFnYgbatBwJWEFNnwY0H3Z7HGBMiVqqjSHObLBaKSBdVnZ/eICLdgG9CE5YxJt9QhfUfOXMmUpKh45PQ4i4r1VHEZDfPYovvQ2C0iBzDuU10LlAWpx/j0ZBGaIwJnwNbnQ7srUuhZiu4ZjxUuDjcUZkwyO6jwWFgeDbbBfh3UKMxxuQPaanOUNhFT0OxElaqw2SbLIaqarZDVD2T4IwxhcneDc7kuj/WQZ2u0OMVKHdBuKMyYZbdpDw3cxkeAG4IXjjGmLBJSXbKdCx/GSLLWqkOk4HblfK2ZLGpShBjMcaEi2+pjsv7QdfnrFSHycDtcAb//osonNLivwU5HmNMXvIv1TFwKtTpHO6oTD7kNln0UtVtfm1fish04KXghmSMyRMZSnXcCh1GO7efjAnAbW2obb6PRaQkcBnQIAQxGWNC6a+DzvKm338E5S+Gm+dCzZbhjsrkc277LNLIXCb8OPBw0CMyxoSOb6mO1iMg5mEr1WFccXsbahU+lWGBk0CiqqYGPyRjTND9uQfmPAAbZ0KVK2Dw507JDmNccpss7lbV37PbQUSiVXVtEGIyxgSLb6mOUyeg4xPQ4m4r1WFyze1PzCQRuZcsVqjzGAc0OuOIjDHBcWArzBoOW5ZYqQ5zxtwmi3OBBOAYcAA4D4gE/uDvBFI56NEZY3IvvVTH4jEgxZ0Z2I1vtlId5oy4TRYfAatVdWZ6g4j0BOqp6vOex5+FID5jTG74luq4pAtc/QqUqxbuqEwh4PajRmvfRAGgqjOALj6P+wUzMGNMLqQkQ8Kz8FZbOLjNKdUx8FNLFCZo3F5ZnCciTVU1fR1sRKQFUCE0YRljXNu5Fr68C5I2wuV9PaU67FfTBJfbZPEIsEhE9gD7gIpAJcCuJowJl5PHnH6JlROh7Pkw8DOo0yXn5xlzGtzO4J4rIrWAHkBVYDcwW1X3hzA2Y0xWNifAzHucUh3RQ5whsVaqw4SQ68HWnsQwWUQ6q+pXIYzJGJMV31Id510EcXOgVqtwR2WKgNOZmfMIYMnCmLy24UuY8yAc2wet7/OU6jgr3FGZIuJ0koWthGJMXspQquNyGDTVSnWYPHc6yWJe0KMwxmTmX6qjwyhoeQ8ULxnuyEwRlKtkISKVgbkiIkAxKyRoTIj4luqo0RJ6jocKl4Q7KlOEuZqUJyJVRGQBziio6UA5YJ2INAlWICJST0QSRORrEVkvIg/7bGsoIitE5BsRmSkitt6jKZzSUmHFGzCxpTN/osfLEDfbEoUJO7czuN8CpgHlge2qegjoDDwbxFg+AL5V1dZAR+BhEekqIqWAL4FHVbUV8B3wZhDPa0z+sHcDvNsZ5j8KtdrAP1c5K9hZTSeTD7j9KSyrqhNV9SCeRZBUNTEXz3ejAbDCc+z9wCbgKpy1vlNVNcGz3ztAbxGpGMRzGxM+KSf/LtVxYAv0fidTqY7EIyfo99YKEv88EcZATVHm9o99hIhkqG0sIjWAUkGMZTZwjefYF+Ikj1VAE+Dn9J1UdQfOKn1WDt0UfDvXOkli6XPQ4Dq4aw1c0Rck46DD8Ys2sWbbAcYv3BSeOE2R57aD+0ngOxFZA9QTkZlAM2BgEGMZAswQkc04JdBHqOpiERkAHPbb9xBOuRFjCqaTx2DxM7ByApSpCgM+hbpdM+1Wd+RcklPSvI8/WrWdj1ZtJ6JEMX4Z0y0vIzZFnKsrC1WdD1wJLMLp4P4WaKqqC4MYyzRghapeBFwBjBCR9KsH//W/IcB8DxEZKiJrRWRtUlJSEEMzJog2J8CEFrDyDYi+xembCJAoAJY/1I6eDc8nsqTzqxpZshjXNjyf5Q+3y8uIjclVuY+twFjfNhHpr6qfnGkQIlIPp1N7kOdcOzyjrx4EtuD0XfiKAhIDxDgJmAQQHR0dKMEYEz5/HYSvRjpzJ1yW6qhUNpIyESVITkkjokQxklPSKBNRgkplIvMoaGMcrpKFZ0RSL6A2Gfsp4oAzThY+xzzl03YKKAusAfr7xFIdOBtYF4TzGpM3NsxwZmGfRqmOfUeTGdSsJgOb1mDK6u0kWSe3CQO3VxbTgRrAj4DvT2qwPt78jLNE6wBggoiUAXoCE4G5wKsiEqOqS4FbgGmqaveZTP73515PqY4ZTqmOgZ/B+Q1zdYi3boz2/nvMdZcFOUBj3HGbLKoAV6hqhls7InJbMIJQ1WQRuQ54xdOhXRonQb2qqimebRNEJBU4iHNFY0z+pQrf/8eZM3HqBHQYDS3vtlIdpsBymyzWAGWAI37tQZtnoaprgbZZbFsPtAjWuYwJqYPbYOa9nlIdLaDnazYD2xR4bpNFOeAnEVlFxoTRFWd2tzEmLRVWvQWLnwYp5pTqaHyLzcA2hYLbZNEcZ+a0v+QgxmJMwZW40VkH+4+1cEln6PEKRFUPd1TGBI3bZDFWVd/2bxSRX4McjzEFS8pJ+PoVWPYSRJRxSnVc3ifTDGxjCjq3a3C/LSLFgJZANWAHzgS6j0MZnDH52s61MONuSNwAl/eFrs/BORXCHZUxIeF2nsXFwEygJs5opHOBbSJyjapuDmF8xuQ/Lkt1GFOYuL0N9RowBvhYVdM8Vxn9gddxqsIaUzRsWQIz7oFDvzulOjo+CZFlwx2VMSHnNlmcpar/SX+gqmnAFBEZGpqwjMlnMpXqmA21Woc7KmPyjNtkUVJELvK95eQpI346a3gbU7D4lupoNRxiH3FdqsOYwsLtH/unge898yySgIpANNAnVIEZE3ZBKNVhTGHhdjTUPBG5EqefohrwP+BWVd0WwtiMCQ9V+H6Kp1THX9BhFLS8x0p1mCItNyXKt+BXotyYQufgNpg5HLYkWKkOY3xYn4Mx4JTqWD0JFj3llOro/hJED7FSHcZ4WLIwxkp1GJOjLJOFZ1jsQVWdmofxGJN3Uk7C1/+GZS9aqQ5jcpDdNfYw4CsAEXkm0A4i0iEUQRkTcjvXwaQYWDIW6l8Ld62BK/paojAmC9ndhhKclfAOk/VaEo8Bi4IdlDEhc/IYJIx1SnWUrmKlOoxxKbtk8S6wQ0SKA3hWqfMlgGZ6ljH5VaZSHU9AZLlwR2VMgZBlslDV10RkEs6Sqp/gzLHwJYBVnTX531+HPKU6PrRSHcacpmxHQ6lqMvC7iPRT1R3+20WkX8giMyYYNs6E2Q/AsSQr1WHMGXA1iFxVd4hIKxF5R0Tmeb63DJRAjAmXxCMn6PfWChL/POGU6vjsH/DpYChdEW5bDJ2etERhzGlylSxE5B/AVCANWOf5PlVEBocwNmNyZfyiTazZtp/ln70KbzSFX+Y5pTpuS7CaTsacIbeT8u4ALlfV/ekNIlIeZ0Gkj0IRmDFu1R05l+SUNKpJEh+UeIe2O35gdVpdRqXdzrw2Q8IdnjGFgttkcco3UQCo6n4RORWCmIzJleUPtGX5lLF03fs2ivBk2i0crDeYyVc3CHdoxhQabgvfJInIKBGpJiIRnu8jgcRQBmdMjhJ/ptLn13J94uusTruUq1NfIv5UR0pHlqJSmchwR2dMoeH2yuJO4D/AE/w9t2IBcGMwgxGRW4GbPecoC9ytqktFpCEwEaev5AAQ53+lY4oYv1Id71b6F1ur9mBCs5pMWb2dpD9PhDtCYwoVUXU/r05EzsdZz2KHqu4OaiAifYHewGBVTRWRm4HjwHRgE06CSBCRJ4H6qto3u+NFR0fr2rVrgxmiyS92roMZd0HiBrisD3R7Hs6pEO6ojCkURGSdqkb7t+eq6qyq7gJ2BS2qjEYB/VQ11XOu9wFE5FogVVUTPPu9A2wTkYqqmhSiWEx+dPI4JDzjU6rjE6jbLdxRGVMk5Iti/SJSCagHNBSRBBFZLiK3ezY3AX5O39czt+M40CjvIzVhs2UpTGwBK16HxnHwz5WWKIzJQ/llPYtaOOVDegEdgUrAahE5DFTGKWbo65BnH1PYZSjVcaGV6jAmTFwlCxFpCxxR1e9DFEcEzlXOa57bULtF5EPgFuB3AhcszFRL2rMGx1CAGjVqhChUk2c2zoLZ91upDmPyAbe3oWYCdUMYx0HP970+bTtxOtMTgSi//aMIMGxXVSeparSqRlesWDEEYZo84S3VMQjOqQi3LbJSHcaEmdtksVxVP/VvFJHYIMWxCacfwvfWUkWczvQ1+CQqEakOnI1TdsQUJqrw/ZSMpTqGJsD5V4U7MmOKPLfJYo6IPCYil4tIjfQvYGwwgvBUt50MDAEQkXOAG4APgLlACRGJ8ex+CzDNRkIVMgd/h496wxfDoOKlcMfX0OZ+KF4y3JEZY3Dfwf265/vTfu3BXPzoAeBNEVkHpADxwEeqqiJyHTDBswDTQSAuiOc14ZSWCqvfhkVPOUuadn8JoodAsXwxUM8Y4+E2WSxV1Xb+jSIyP1iBqOoxspgRrqrryXppV1NQJf7sTK7buQYu7gRX/xuiqoc7KmNMAG6TRedAjaraJYixmKIivVTH8pegVGnoNQmu6OdcWRhj8iVXyUJVT4nIQJxP/sVwllh9FHhcVa0Ij3Hvj3XwZXqpjuuh6/PO4kTGmHzN7eJHo4B/AvOBc1X1ILABeCuEsZnC5ORxmP8YvNPRmWg34BPo854lCmMKCLe3oToCbT0F/q4Fp3aTrZRnXNmyFGbeAwe3QeObnTkTkeXCHZUxJhfcJovi6QX+8IyAEpFiOPMdjAnsr0Ow4HH4brKV6jCmgHObLL4RkYU48x7OFZHrgYFAQvZPM0WWt1RHIrS6F2L/ZTOwjSnA3CaLR4GHgcdxSnCMxZkH8WJowjIF1tFEmPMgbPgCKl8OAz+xGdjGFAJuR0OlAM94vozJTBX++zHM+xecOg7tH3euKGwGtjGFgusS5SLSEWfIbFVgN/Cxqi4KVWCmADn4O8waDpsXQ/Xm0PM1qFgn3FEZY4LI7dDZh3FqNwH8iFMe/CMReShUgZkCIC0VVr4JE1rAjtVOqY6b51qiMKYQcntlMRho4JlfAYCIlAeWAi+EIjCTz2Uo1dHRU6rD1hAxprBymyx2+iYKAFXdLyK7QxCTyc9STsI342DZi1DqHCvVYUwRkWWy8JQgTzdHRMYAU3Gqvp6H039hfRZFyR/r4Mu7IfEnK9VhTBGT3ZXFNpwJeL4fGR/120eB54Ick8lvTh6HhGdg5QQoXRn6fwyXdg93VMaYPJRdsghYltyXiNikvMLOSnUYY8g+WQQsS+7H5l0UVv6lOm6aBbXbhDsqY0yYZJksVPWU72MRaQpcCJTyaX4EqB+a0EzY+JbqaHmPU6qjlJUBM6YoczUaSkTigW7ArzhLnqarEoKYTLhkKNVxGQz4GC5oFO6ojDH5gNuhs1cB1VX1pG+jiDwe/JBMKCUeOcFdH6/n9YFXUalMpNOYqVTHSGg13Ep1GGO8XM3gBr4l4+2ndIlBjMXkgfGLNrFm2wHGL9zkNBz8HT7qDV8Mg4p14Y6voe2DliiMMRm4vbJ4DlgsIr8Df/q0d8VWyysQ6o6cS3JKmvfxlFXbKL72bR4q8QnnlCoB3V6EJrdCMbefH4wxRYnbZPEp8AfwMxn7LJKDHpEJieUPtWPMnI189dMeqqVs58VSb3OVbCK5Vnu47lUr1WGMyZbbZJGiqr38G0XkuyDHY0KkUtlIokoqt+n/cXep6Rwjks+rj6TPTQ9YqQ5jTI7cJosvRKSJqq7xa+8OzAxyTCYU/ljH0F+GUK3EVg5feA1vnnU7206cRR9LFMYYF9wmi38CY0TkT/7usxCgMjAsWMGIyCXABqCTqi7xtHUEngVSgV+A21X1RLDOWej5lOqoVroy9J5CuUt78K9wx2WMKVDcJotDQJxfmwD/DmYwwFOAd3iuiFQEPgFaquqvIvIB8DTwYJDPWzhtXQYz7vaU6oiDTk9ZqQ5jzGlxmyyGBrgFhYgMDFYgItIEOAok+TQPBP6nqr96Hr8DzBCRR1Q1NVjnLnR8S3WcWxtumgm124Y7KmNMAeZqnGSgROFxRxBjedLz5asJzgisdBuAKODiIJ63cPl5NrzRDNZ/5JTqGPatJQpjzBlzW+5jcRabGgL3nmkQItIN+ElVd0rGDtfKwA6fx4c83yvh9F+YdEcTYe5D8NN0K9VhjAk6t7ehqpJx3YoooAvw2pkGICLFgIeB3lnsooGelsWxhgJDAWrUKCLzBlThv5/AvEesVIcxJmTcJoubVXWlb4OIvIbT+XymBgLzVfVAgG2JOIkpXZRPeyaqOgmYBBAdHR0oyRQuh7bDzOGweRFUbwY9X3NKdhhjTJC5Shb+icLjPOCKIMTQBrhMRLp4HlcBxnlKiyQA1/jsWx/nVtRvQThvwZWWBmvehoWeLh4r1WGMCTG3fRZb/JoigArAy2cagKre7neubcBwVV0iIpWAkSJyiapuAm4B3lHVlACHKhqSfnGGw+5YBRd1gGvGWakOY0zIub0NdRgY7vP4JPC7qu4KViCexZVe4O8ri2mq+pSI9AemiEgqznoaRbMseuop+HocLHsBSp0Dvd6CK26wUh3GmDzhNlkMVNWNoQxEVVcDsQHaFwILQ3nufO+P75yrib0/QoPe0O15KF0p3FEZY4qQLJOFiExPLx4Y6kRhsnDyOCwZCyvegNKVof8UuLRHuKMyxhRB2V1ZxHrmVwh/D19Nv+eR/lhVtUOogivSti6DGffAwa3Q6CanVMdZUeGOyhhTRGWXLL5X1fb+jSJyEfAuUI/gzuA2ACcOw4JRsC7eSnUYY/KN7JLFP/wbROQ+nEJ+s4E+qrovVIEVST/Pgdkj4OheaHk3xD4Kpc4Od1TGGJN1slBVb5kNEbkUeB+4CLhFVT/Lg9iKDv9SHf2nWKkOY0y+ku1oKE8pjkdwhqvOBa5V1YCzp81pUIX/feqU6jh5zEp1GGPyrexGQ10BvAfUwrma+DjAPiNVdUzowivErFSHMaYAye7KYi3O6Kd3gUtEZJTfdgFuAixZ5EZaGqx5BxY+4Ty2Uh3GmAIgu2TxExlnbQdyXdAiKQqsVIcxpoDKLlk8qapLs3uyiPgvVmQCST0F34yDpVaqwxhTMGU3GuqLnJ7sZp8iL0Opjl7Q7QUr1WGMKXDc1oYyuXXyOCx5Fla8bqU6jDEFniWLUNi6HGbeAwe2WKkOY0yhYMkimKxUhzGmkLJkESxWqsMYU4hZsjhTR5M8pTqmQaUGVqrDGFMoWbI4Xf6lOtqNhFb3QolS4Y7MGGOCzpLF6Ti0A2YNh98WQrWmcO3rVqrDGFOoWbLIjbQ0WPuuU6pD1Zkz0eRWKFY83JEZY0xIWbJwK+lXT6mOlVaqwxhT5FiyyEnqKfjmVVj6vFOq47o34cr+VqrDGFOkWLLIzq718OXdsPcHK9VhjCnSLFn4STxygvumrGRS9QWcs3YinFMRbvgP1Ls63KEZY0zYWLLwM+PLzxizawzn7NlrpTqMMcYjX6y4IyIlRWS4iCwRkaUiskJEOvhsb+hp+0ZEZopI+WDHUHfkXGo9Mpu0X+YhwICTj1Hr2y7UfWZFsE9ljDEFjqhquGNARGoBCUBDVT0sIp2A6UBdIAnYBMSpaoJnDY36qto3u2NGR0fr2rVrXceQeOQEY+ZsZOlP20k+lQolz6JLgyo81qMelcpEnu5LM8aYAkVE1qlqtH97frkN9ScwSlUPA6jqAhE5AbQETgKpqprg2fcdYJuIVFTVpGAFUKlsJGUiSnAkpQSlSpTiZEoaZSJKWKIwxhjyyW0oVd2vqh+mPxYRAUrhXFU0AX722XcHcBwIegGmfUeTGdSsJtPvbMWgZjVJOpoc7FMYY0yBlF+uLPzFAL8Dy4BBwGG/7YeAoI9hfevGv6+8xlx3WbAPb4wxBVa+uLLwJSKRwFicPoo0T3OgjpVMs+JEZKiIrBWRtUlJQbtDZYwxRV6+Shae20+TgH+r6jpPcyIQ5bdrlKc9A1WdpKrRqhpdsWLFUIZqjDFFSr5KFsDLwGpVnSoiESJSA1iDMyoKABGpDpwNrMviGMYYY4Is3yQLEXkYpw8lXkRKAxcBtwBzgRIiEuPZ9RZgWjBHQhljjMlevujgFpE6wHOeh3f7bHpSVZNF5DpggoikAgeBuLyN0BhjirZ8kSxU9VcCdFj7bF8PtMi7iIwxxvjKFzO4Q0FEknCG3xYEFYB94Q4iRArza4PC/frstRVcZ/L6aqpqphFChTZZFCQisjbQ9PrCoDC/Nijcr89eW8EViteXbzq4jTHG5F+WLIwxxuTIkkX+MCncAYRQYX5tULhfn722givor8/6LIwxxuTIriyMMcbkyJJFmOS0OmBhISKXiMgpEYkNdyzBJCK3elZu/FpE/udTYaDAE5F6IpLgeW3rPdUVCiwRaSIiv4lInF97yFfgDLVAr01EaonIeyKyWERWisjHInLGxfIsWYTPBcC9wLWqGgOMAr4UkQvCG1bQPYWzgFWhISJ9gQ5AW1VtDfwbqBLeqILqA+Bbz2vrCDwsIl3DHNNpEZFewH34LXMgIqWAL4FHVbUV8B3wZt5HePqyem04FS4OqWp7nMnMqQShD8OSRfhkWh0QSF8dsFAQkSbAUZxFrAqTUcBTqpoKoKrvq+qnYY4pmBoAK8BZmAxnWeOrwhrR6VujqgNxft98dSPzCpy9g/EJPA9l9dq+A94AUKdT+hOg05mezJJFmOSwOmBh8aTnq9AQkUpAPaCh51bNchG5PdxxBdls4BoAEbkQJ3msCmtEp0lVd2axKc9W4AyVrF6bqs5Q1c0+TZEEYbZ6vqgNZYCMqwMWeCLSDfhJVXc6ebDQqIVTx6wXzi2aSsBqETmsqp+EM7AgGgLMEJHNwHnACFVdHOaYgq0yebQCZz5wNZ4rjTNhVxb5QBarAxZYIlIMeBh4NtyxhEAEzu/Na6qaqqq7gQ9xSucXFtOAFap6EXAFMEJECswn7lxwtQJnQSYiLXGWexh3pseyZBFmWawOWNANBOar6oFwBxICBz3f9/q07QSqhSGWoBORejhXTOPAe3tmAfBgGMMKBdcrcBZUIlITZ+mHPqp66kyPZ8ki/AKtDljQtQGu9gwLXoIzUmiciHwZ3rCCYhPOvW3f2xUVgV3hCSfoSnm++/5xOQWUDUMsoVSoV+AUkQo4V7xxqrpXRGqISMSZHNOSRRhlszpggaaqt6tqK1WNVdVYYA8wXFWvDXNoZ0xVk4HJOPf1EZFzgBtwhpsWBj8DfwADAESkDNATKGx9FoV2BU7P35L/wxm1l+h5fAdQ9YyOa+U+wsOzOuAvATY9qapP5HE4ISEiTYEXgOY4f4SmqepT4Y3qzHkSxJtAfSAF5xfzRS0kv0wiEg28gnP/vjSwEPiXqqaENbDTICKNca7eG+J8aNmgqr09264CJuDMQziI8yl8f5hCzbWsXpuIPAM8GuAptVV122mfr5D8fBtjjAkhuw1ljDEmR5YsjDHG5MiShTHGmBxZsjDGGJMjSxbGGGNyZMnCGGNMjixZGBMGIvKaiBzyX5DHmPzKkoUxYaCqdwPfhzsOY9yyZGGMMSZHtp6FMXnEU0bjTZwVEddQyMphm8LNriyMyQOeNZ+nAy971rb+AGgW3qiMcc+ShTF5owVOWfPPAFT1e+DXcAZkTG5YsjAmb1QFDqlqqk9bYVwcyhRSliyMyRu7gSgR8e0nLB+uYIzJLUsWxuSNFThLdt4AICINgXrhDMiY3LD1LIzJIyLShL9HQ/2Es3hSBeAhVZ0RztiMyYklC2OMMTmy21DGGGNyZMnCGGNMjixZGGOMyZElC2OMMTmyZGGMMSZHliyMMcbkyJKFMcaYHFmyMMYYkyNLFsYYY3L0/y13Q1FnZm8IAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 11;\n",
+       "                var nbb_unformatted_code = \"count_gates(\\\"rb\\\", num_trials=10, seed=0)\";\n",
+       "                var nbb_formatted_code = \"count_gates(\\\"rb\\\", num_trials=10, seed=0)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "count_gates(\"rb\", num_trials=10, seed=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "1b0ae199",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depth\tnum. twoq\tnum oneq\n",
+      "-----------------------------------\n",
+      "1\t2.0\t\t26.2\n",
+      "3\t6.0\t\t45.6\n",
+      "5\t10.0\t\t67.6\n",
+      "7\t14.0\t\t87.2\n",
+      "9\t18.0\t\t108.4\n",
+      "12\t24.0\t\t138.4\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYQAAAEQCAYAAACwSgOGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAAA/xklEQVR4nO3dd3wU1RbA8d8JhN5LAkizQECq9J7QVIpgQUCKBFQUBeXpU1CxgyJ2RFQsIDywi0pVqkgvgr0g0g2EXk0/749J1hCSsIHdTLI5388nH7IzszNngOTsvXPvuaKqGGOMMUFuB2CMMSZnsIRgjDEGsIRgjDEmmSUEY4wxgCUEY4wxySwhGGOMASB/dlxERIKBu4BrAQEKAGNUdUny/n3Ab6neslJVx2RHbMYYYxySHfMQRKQ6sAxoqKrHRKQzMBsIU9W9IjJNVSP9HogxxpgMZVeX0QngUVU9BqCqi4AYoFU2Xd8YY8w5ZEsL4ayLighwDOihqstFZB1wGCgO/AI8pKoHMztHuXLltHr16n6P1RhjAsmmTZsOqmr59PZlyzOEdIQDO4EVya9/BkbitCQmAAtEpJmmyVYiMhQYClC1alU2btyYbQEbY0wgEJGdGe7L7haCiBQClgIjVHVTOvuLAseBVqq6LqPzNGnSRC0hGGNM1ojIJlVtkt6+bB12mtxVNAV4Kb1kAKCqp3C6j6plZ2zGGJPXZXeX0QvAelX9WEQKAqHAZcBxVd0IICIFgNLA39kcmzHG5GnZ1kIQkVE4CWiaiBQDLgWGAFWBYcmtB4ARwDYgw+4iY4wxvpddE9NqAuOTX45ItesJnOcJ7YBvk5PCCeAaVY0/3+sdP36c6Oho4uPP+xTGmByoaNGiVK5cmaAgK7LgD9mSEFT1D5wZyhkZ4qtrHT9+nP3793PRRRdRuHBh/m14GGNys6SkJPbu3cvBgwcJCQlxOxzXRB+PYfj7m5nU7wpCihfy6bkDLs1GR0dz0UUXUaRIEUsGxgSQoKAgQkNDOXbsmNuhuGrikq1s2HGYiYu3+vzcbs1D8Jv4+HgKFy7sdhjGGD8IDg4mISHB7TBcETZmAbEJSXQK2sSNQcf537r2/G/dLgrmD+L3sV18co2ASwiAtQyMCVB5+Wd75fC67Jo5gsYnlrEpqQZzgtpzZZ1KPNytts+uEZAJwRhjAoYq/PAR5ReOonTMSZ5P6M1UehCTCMUL5vfpc4SAe4aQk9WqVYuIiAgiIiKoUKECoaGhnte1atVyO7yzxMXFERERgYiwY8eOdI+ZNWsWt956a/YG5mMrV67kyiuvzJZrPfPMMzz11FPZcq2suuOOO5g+fXquPX9AOrYHZvWG2UOhbA2eqvwmR5vcw8d3htO/eTUOnIz17fVUNVd+NW7cWNPzyy+/pLs9JwgPD/d8P2jQIO3fv3+6+3IaQLdv357uvoSEBD1x4oTn9aBBg/Sxxx7zSxzbt29X57+sbyUlJenRo0d9ft70xMTE6D///JMt18qqEydOaHx8fLadv1q1arps2bIsnycn/4z7TGKi6vq3VMdVUh1bQXXN66qJCT45NbBRM/i9ai2ENKKPx9D7zTVEn4jx+bmfeeaZ89qXk+XLl49ixYq5HcYFERFKliyZLdcqWLAghQr5dqigrxQrVoz8+f3Xi+zv8weMg3/CtG4w7z6o3ATuXAMt7oCgfH6/tCWENPw5pKtly5YZ7itfvjyXXXYZISEhjBs3DoCHH36YUaNGAfDOO+8QGhrKfffdB8CGDRsIDw+nXbt2hIeHs2HDhgzPvW3bNtq2bUvLli3p378/119/PdWrV2fKlCncfPPNFCpUiOXLlwPQs2fPdLuIvvjiC66++mrq1KnD+PHOHMMff/yRhg0bklKG/JVXXmHhwoVMmzaNiIgI3nnnnXTjmTp1KnXr1qVjx45MnDgREaFFixbs2rWLn3/+mW7dutG5c2datmzJlClTADh27Bh9+/YF8HSzJSYmEh8fz/3330+rVq1o06YNTzzxBJpcsHH16tW0adOGDh06EBERwdy5c8+K5cCBA7Ro0cLzsHL9+vWee3ruuecIDw+nfv36/PHHH+ney5NPPkmFChUYPnw4AwYMoGbNmowaNYr169dz7bXXcskll/D5558DsGjRIk+3IcCUKVOoXr06ffv25bbbbqNhw4ZERERw5513UqpUKR555BGuv/56qlatyuOPP46q8txzz9GiRQvatGnDkCFDOHHiBECG70krISGB0aNH06pVK9q1a0fv3r3566+/mDFjBtWrVycyMvKM+xoxYgT9+vUjLCzMs2/mzJm0aNGCDh060KFDB5YsWcLSpUvPuLfZs2efcb605x88eDD79u1j5MiRREREsGnTJn777TfPOdu2bcu0adPS/TsPWIkJsPJleKM1RP8MPV+DgZ9D6erZF0NGTYec/uXrLqOaD8/XaqPmnvVV8+H553W+c0nbZaSqumjRIq1Zs6bndePGjbVu3bqe171791ZV1aNHj2rZsmU9ze0VK1Zo2bJl9ciRI+leq1mzZvr000+rquqePXu0RIkSZ3TrpG26k6aLCNAHH3xQVVUPHTqkFSpU0K+++kpVVZctW6bVqlU7474y6zL66aeftHDhwvrXX3+pqurEiRPPuN7atWt17dq1qqoaFxentWrV0j/++ENV0+8yGjt2rLZv314TEhI0Li5OW7ZsqTNmzFBV1aZNm3rOtWXLFh00aFC6MaU977JlyzQ4OFi//fZbVVUdNmyYDh06NMN7GjRokDZu3FhjY2M1Ojpag4OD9amnnlJV1U8//VTDwsI8x06dOvWM7sHHHntMQ0NDNTo6WhMTE/WBBx5QVacLsXPnzpqQkKC//fabvvXWWzp9+nS9/PLL9dSpU6qqesstt+iQIUM850rvPWmNGzdOO3XqpAkJTvfDXXfdpVOnTvXEkvrvaNCgQVq3bl09deqUHj16VJ966ildtWqVJ15V1Y8//tjznvTuLfX50r5O+//uxhtv1A8++EBVVaOiovTqq69O9+87ILuMon5QfaOt6mMlVN/vp3o8ym+XwrqMzu3bB9rTo2ElCgU7fyWFgoPo2bAS345qn20xtGvXjqioKP7880/27t1Lo0aN+OOPP9i9ezd//fUXl1xyCQBz586lRIkSnk9jbdu2pXTp0nz55ZdnnXPnzp2sX7+eAQMGAHDRRRcRHh6e5dhuvPFGAMqUKUPXrl354IMPzuseP/nkE1q2bMnFF18MQP/+/c/YX6NGDd555x1atWpF586diYqKYvPmzRmeb9q0aQwaNIh8+fIRHBzMjTfeyIwZMzyxzpgxg/3799OgQQMmT57sdZzFihWjTZs2ANSvX5/t27dnenx4eDgFChSgfPnyhISE0KBBA897//rrr0zf27JlS8qXL09QUBDPPvusZ3u3bt3Ily8fYWFh3HrrrUyfPp0+ffpQpEgRwPmUPWPGDBITEzN8T1pTp05l4MCB5MvndD889NBDmf5/6NSpE0WKFKFkyZKMGTOGqVOn0rVrV8qXd9ZXufbaaxk2bFim9+etMmXK8Mknn7Bjxw4qVKjAp59+6pPz5mgJsbB0LEyJgON/w43vQZ//QfEKroRjCSFZSIlCFC+Yn9iEJArmDyI2IcnnQ7rOpUCBAnTu3Jk5c+Ywf/58+vbtS9u2bZk3bx5z586lW7duAOzZs8fzA5mifPny7Nmzh4ULF3q6VMaPH09UVBQA5cqV8xxbpkyZLMdWunRpz/dly5b1nDeroqKiMo3l3nvvJTo6mm+//Zbly5fTsGFDTp8+neH59uzZw4svvui555kzZ3p+Qc6aNYsiRYrQqFEjrr766gy7fdJTokQJz/eFChUiLi4u0+OLFy/u+T5//vye1/nz5z9nTa2Mnl+k3Z723718+fLEx8ezf//+c54ro3NUqlTJk5zPJ4b8+fPTvHnzTK/prZdeeokGDRrQoUMH2rRpw9q1a31y3hxr1zp4ow2seA7q9Ya71kOda8HFuRaWEFI5eDKW/s2rMfvO1v4Z0uWF7t27M3fuXFavXk3btm3p1q0b8+fPZ82aNZ5nEFWqVOHAgQNnvO/AgQNUrlyZq6++muXLl7N8+XJGjx5NxYoVPftTHDp06Iz3FihQgNhY516PHj2ablyHDx/2fH/w4EHPebOqYsWKmcayfv16OnXq5PkEe65fplWqVGHMmDGee16/fj0fffQRALGxsUyYMIGdO3fSrl07evbseV4x5xRp/90PHDhAcHAwoaGh532OQ4cOZTik2Jv3JyQk8P333wNn/j+CjP8vZeTo0aOMGTOGbdu2cfvtt3PNNddw6tSpLJ0jV4g9CQtGwbtXQfw/MOBTuO51KJL1D2q+ZgkhlTcHNmHstXW5vFIJxl5blzcHpruokF917dqVVatWERQURHBwMN27d2fJkiUULlzY80uye/funDhxghUrnBVIV61axZEjR+jRo8dZ56tWrRrNmjXzdKPs3buXVatWnXHMxRdfzE8//QTA/Pnz040rpYvo0KFDntZLeooXL87p06c5derUWd1BAL169WLNmjWebpSUX94pLrvsMtatcyqfR0VF8cMPP5xxboDTp08zfvx41q5dS2RkJLNmzfK0Ct577z3PQ/levXpx+vRp8ufPT+vWrc/oWsmNIiMj+eijj/jnn38A515Td/94e47U3UyjR4/2/EL39v3z58/n4EFnyfMPP/zQ8/D34osvZuvWrcTGxhITE8OyZcsyPVfK/5Vly5bxyiuvMHjwYPbv34+I0K5dO+Lj4wNvZvK2pfB6S1j3BjS7zRlBdFknt6P6V0YPF3L6V26ch5Di/vvv19DQUA0JCdH777//rP1NmzbV9957z/O6Ro0aOmvWrDOO2bhxo4aHh2vbtm21Xbt2un79+gyv9+eff2rr1q21RYsWGhkZqX369Dnjwe+3336rNWvW1I4dO+q0adMU0ObNm+uOHTs0PDxcAR03bpx27NhRa9eu7XlA/cMPP2iDBg20YMGC2qtXL1VVXb16tYaFhWnTpk115syZ6cbz7rvv6uWXX64dO3bUt956SwHdsWOHqqr++uuv2rhxY23RooUOHjxY69Wrp2FhYbpkyRJVVe3Xr582btxYO3XqpKdPn9a4uDgdNWqUNm/eXCMiInTAgAGeh67PPvustmzZUiMiIrRZs2aec6QWHR2tzZs3V0DDw8P1p59+8tzT0KFDdd26dRoWFqYlS5ZM99/qhRde0NDQUK1WrZp+9tlnOmzYMC1YsKA2aNBAf/vtN8+5O3furF9//bXnXMOHD9eZM2dqtWrVNDQ0VAcOHOg55/33368lS5bUsLAwfeGFF8643nPPPactWrTQ1q1b6+DBg/X48ePnfE9qKX9fKed46KGHVFV1+vTpnljGjh17xn2lve8ZM2ZoixYtNDw8XG+44QY9duyYZ9+AAQP08ssv1/79++vw4cM950t7flXVV199VWvXrq3NmzfXn376SadNm6atWrXS9u3ba+PGjT0PmNPKDT/jZzl9WHX2nc5D44mNVXesdi0UMnmonO1rKvtKRmsq//rrr9Su7bvaHoEoMjKS6tWrpzssMTscPnzY8+zgwIEDhIaGcvLkSc/DUmMyk+t+xn+d48wpOHUQWt8D4aMg2L25KDlmTWVjEhIS6NGjB0lJSYAzPr1NmzaWDEzgObEfProZPhwAxUJg6DLo9JiryeBcbNpgHjNu3DgWLlxIoUKFqFSpEkOHDs3W6+fLl49LLrmEli1bEhwcTLFixay+jQksqvD9+7DwQeehccdHodXdkC/Y7cjOybqMjDG5So7+GT+6C+aMhG1LoEoL6PEqlK/pdlRnyKzLyFoIxhhzoZKSYMPbsPhx53WX56DprZDL1n62hGCMMRfi4Fb4YjjsXguXdoRrXoZSVd2O6rxYQjDGmPORGA+rJ8LyZyG4MFz7OjS4ydWZxhfKq4QgIs2Bq4DxQCVgGs4IpbtU9Ue/RWeMMTlR1PfwxV2w70e4vKfTRVTc+xnjOZW3LYQngUlAPPAs8BOwPnlb1iulGWNMbhQfA9+Mh1UToWg56D0DLj+7QkBu5e0TjyBVnQOUANoB96nqdCDJb5EFoJQa825MCFuxYgWNGjWiWbNmREZG5ojlDOfMmcOVV15Jhw4daNSoERMnTsz0+C1bttCyZUtat27NNddcc1YdpOz0448/0rt3bzp27EjTpk258847MyzCd/LkSR5//HHP+hURERF89913531tVWXChAkUKFDgrH3Tpk3zrKuQ8rVy5crzvpZJZecaZ62ClS85XUN3rQuoZAB4V7oCWA2UAx4CJidvCwJWevN+f3zl1tIV/lhiMjw83FPTPiNt2rTxlJKYPHmyz5YzvBCXXnqpfvfdd6rq1L8vU6aMfv755+keGxsbq1WrVtWlS5eqquqjjz7qKZfhhkGDBukrr7yiqk45iIiICB05cmS6xy5btkxbtGihMTExqqo6ZcoUrVixop4+ffq8rj1w4EAdM2ZMusuJTp06Ndv/HbNbtv+MxxxXnXufU3bipbqqf55dAiU3wQfrITwL/AwMAMaJSAWcLqMAr08bOPbs2UOlSpUAGDZsWI5YzvCuu+7iiiuuAKBChQq0b9+er7/+Ot1jFyxYQL58+Wjf3lmf4tZbb+Wzzz47q+rrhapevbpX1T/Dw8MZNGgQAMHBwdxwww0Zxl6xYkUeeeQRChYsCMBNN91EVFSUp6BgVj399NPccsst5/Vek0V/LobJLZ0hpc3vgGFr4NIObkflN14lBFX9QlVDVfVyVd2rqvtUtYmq/tffAQai6OhoevXqRbNmzejWrZunciTAV199RcuWLQkPD+eaa67h77//BpwKn7179yY8PJw2bdrwn//8B4AHH3yQLVu2MH78eCIiIpg3b95Z17v++uuJiopi5MiRdOnSxavlDDPz+uuvU7x4cWrXrs3KlSs5cOAAjRo14uKLL+bHH70fY5ByDyliYmLOWuchxYYNG6hVq5bndZUqVShSpEi6XS/9+vUjKCiI1q1bExcXR/369bnssstYtGiR17Gdy+DBg89YKyCz2MPCwujatesZx8KZa1SkLI3Ztm1bRowYken6C5UrV840tjfffJPw8HAiIiKytCiQSeX0YZh9B/zvBmcE0ZCvoMuzUDB3rx9+Ll5/RBSRVsBAoCBwD3AzTvdRzp7qvGC0MxLAnyrUgy7jvT586dKlbNiwgeLFizN06FDuvvtuZs2axfbt2+nVqxcbN24kLCyM1157jZtvvpnFixczbdo0ypYty0cffURiYiItWrQA4JlnnmHNmjVERkZ6fsGn9dlnn1G9enVefvllzypr27Zt83wSnjp1KsuWLTtjf0xMDJdeeimzZ8+mWbNmZ5xv2LBh/Prrr8TExHhWFevfvz+NGjWiXr16TJs2LdP1cFPWb07t+PHjbNiwgddeey3d9+zfv/+sxVpKlSpFdHT0WcfOmjWLkiVLsm/fPgoUKMAVV1zB+PHjz3sNB2/MnTuXu+66y+tju3bt6lmYZubMmbz77rts2rSJwoUL06dPHyZMmMCYMWOyHEdoaChXXnklkZGRHDhwwLP29IgRI7J8rjxJFX75Aub/F/45Am3/C+3uz9H1h3zJqxaCiNwOzABigYbAaaA88ILfIgtgV111lae2/8CBA/nkk09ITExk1qxZNGnShLCwMMD5pLtkyRKioqIoU6YM3377LevWrSNfvnx88803fo0xODiY2rVrZ7gC180338zHH3/s+bS7bNkyTzKJjIz0LFiT3ld6Ro0axaOPPkq1atUyjCm92vgZfR6ZMGECmzZtom/fvkRERGSYDPbt23fGA9h9+/Z53hMREcHChQszjCfFhx9+SPny5T3LjGbm0KFDvPLKK2d8cp82bRp9+/alSJEiiAg33XSTZ/2KrOrSpQuDBw9GRAgJCWHEiBHWSvDWiX1OIbqPB0GJSnDbMuj4SJ5JBuB9C2Eg0EBVT4rIMlVNBB4XkcxXwMgJsvDJPbukXY4yPj6egwcPsmfPHn755RfPL1ZwFrjZv38/ffv2JSEhgXvuuYdDhw5x7733+mwt2/Tky5ePxYsXZ7i/SZMmVKpUiS+//JKwsDDq1q173ouZTJkyheDg4Ew/YYeEhJy1tvLRo0cJCQlJ9/jixYszbtw4brvtNiZNmpTheStUqHBGkqpevToffPAB1atX9yr27777jrfffpvPP//8nMfGxsYycOBAJk2adEbi27NnD7NmzfIsKBMTE0NQcsmDvn37sm/fPsBZpKhChayttVu1alV27tyZpffkOaqwZSZ89ZCzxnGnJ6DlcMiX9+btenvHqqonU75Ptf3scW/mnNIuRxkcHEy5cuWoUqUKTZo0OeM5wJEjRyhRogQHDx6kT58+DBgwgM2bN9OpUydq1arlecjqhoEDBzJ9+nRq1arF4MGDPduz0mU0e/Zsli1bxqxZswDYunUrNWrUOOs9TZs29azaBrB7925Onz5N48aN072GqjJv3jx69uzJiBEjeP/997N4d+f2559/MnLkSGbPnk3RokUzjB0gKSmJQYMGcfvtt9O6dWuOHTtGbGwsISEhVKlShc6dO3P//fd7jk95rpT6nr0xYcIEHnjgAc/r/fv3ewYTmHQc2QFz7oG/lkPVVk4xunKXuR2Va7wdZfSHiEwVkbZAYRFpLCIvA7/4L7TANX/+fE6cOAHA9OnT6dWrF/ny5eOmm25i3bp1nk900dHRREREkJSUxKRJkzyJol69epQpU8azDGLKUoRbt24945dKVqRdzjAxMZFOnTrx+++/Z/ieAQMGsGjRIn788Ufq1Knj2e5tl9GKFSuYOHEikyZN4tSpU5w8eZKxY8d69vfu3dvTNdalSxcSEhI8r999912uv/76DB/kvvHGG/Tu3ZspU6awYsUKrz7BZ8W+ffvo168fkydPpmDBgpw8eZInnnjCs3/ChAk8//zzntfDhw+nadOmdOzYkZMnT7J69WrPcqWRkZFndb/dfvvt5xXXggULPH9Hp0+f5s0332TgwIHne5uBKykR1r7hjCDasxG6vQCR8/J0MgC8nodQFHgL+AdnMtpp4A2gqDfv98dXbpyH8MQTT2hoaKgOGTJEr7nmGm3SpIl26dJFDxw44Dnmq6++0latWml4eLi2b99e16xZo6qqa9as0Q4dOniWFxw9erTnPZ999pnWrFlTmzZt6hmnn9p1113nWdZxwoQJXi1n+M8//2jFihV13bp1md5Tx44d9cUXXzyvv49KlSopTovT8xUeHu7ZX69ePf3kk088r7/77jvP0o/du3fXgwcPpnvee++9V0uVKqXPPPOMbt68WStXrqylS5fWZ5555pwxVatWTbdv337O4/r163dW7KSaFzB8+HC9++67VVX166+/TvfY1HNHnn/+eW3WrJm2b99ee/bsqfv378/w2mPHjj1j2c8333zTs2/OnDnaoUMHjYiI0CZNmuioUaM0Njb2nPeTm1zwz/j+X1Xf6uTMK5hxg+qRXb4JLJfAV0toitNJXB44AFRS1b0XmpDOl62HkDP069ePF198Mct928acr/P+GU+Mh5Uvw4oJUKAoXP0s1O+dq4vRnY8LXkJTRD4Ez8ef6OQsMypluxfvDxaRkSKyXES+EZE1ItIx1f6GydtWicgcESnrzXmNOw4fPsy8efM4dOgQcXFxlgxMzvf3ZpgSAcvGQq3ucNcGaNAnzyWDc/H2ofJZHbWqereIrPLy/RfhzF1oqKrHRKQz8IWIhOG0Nr4AIlV1mYg8gdMdde4xfMYVsbGxDBs2jNDQUBvSaHK2+H9g+TOw+lUoGgJ9Z0Gtbm5HlWNlmhBEZDtOf2cFEfkrze4iOFVPvXECeFRVjwGo6iIRiQFaAXFAoqqmDGF9G9ghIuVV1bd1CYxPVKxYkV27drkdhjGZ27EKvhwBh7dBo5uh81NQuJTbUeVo52ohRAICvASMTLPvBPC9NxdR1UM4E9sAz7OIAjitg07Ab6mO3S0ip4FGwFfenN8YYzxijjtLWW58B0pVg5u/gEsi3I4qV8g0IajqNwAi0kdV/0i7X0RqkeqXeRaEAzuBFUB/4Fia/UeBs2YcichQYCg4E24ykpSU5JnYY4wJHOccBPPH1zB3JBz/G1rcBR0edh4gG6949QxBVf8QkeJAGE5XUYqXcT7Je01ECgFP4zwzSEqe3Zrev/JZT3tUdQowBZxRRumdv2jRouzdu5fQ0FCCg4PPe/asMSZnUVUOHTpEoULplJI4dQgWjoYfP4LyteCWRVClafYHmct5u4RmT+A1oAywHwgGKgL7snKx5K6iKcBLqppSUjMauCLNoaWSt2dZ5cqVOXjwIDt37iQhIeF8TmGMyaEKFSp0ZrVXVfj5M5j/AMQchfBR0PY+yF/QtRhzM29HGd0P1Aa+VNX2ACJSHxiSxeu9AKxX1Y9FpCAQCmwA+qYcICJVcFohmddgzkBQUBAhISEZ1rgxxgSI41Ew7174fT5UugJ6fgmhdc79PpMhbzvaT6vqCVIlEFX9Aajn7YVEZFTy+6eJSDHgUpyEsgDILyIpazMPAT6zEUbGmHSpwqb34LXmsG0pXDkWbllsycAHvG0hJInIJcBuEXkFZ/RPc8CrGUkiUhNIKTuaujD7E6oaKyLXApNFJBE4gjO6yRhjznT4L6cY3fYVUK0N9JgIZS91O6qA4W1CGAvUBEYB04Fbga3Abd68OXmEUoZPd1V1M9DSy1iMMXlNUiKsfR2WjoWg/ND9ZWg0CGw0oU95mxDWqmrKE1r36i0bY/Ke/b/Al8Nh7yaocRV0fwlKXuR2VAHJ24TwNRC4K0sbY3KehDhY+SKseB4KlYAb3oG6N1j9IT/yNiFEJPfvpyca55nCvap6OINjjDHGe3s3wRfDIfoXqHcjXD0eipZzO6qA521CeBCnwN1M4DBQDqf43F5gDTAAmEyq4aPGGJNlcadh2ThYOxmKVYCbPoCwLm5HlWd4mxDaq+rVqV7vBDaJyHxVfRXYmIXKp8YYc7btK5xidEd2QOPB0PkJKFTS7ajyFG8TQmURKZlSrRRAREoD1VId4/1KO8YYkyLmGCx6FDZNg9IXw6A5cHE7t6PKk7xNCLOAX0RkPnAQp/uoKzAxucbRm2SxjIUxxvD7Apj7Hzi5H1qNgIiHoECRc7/P+IW3xe2eFpEtQC+gIRAFDFHVhSKSD3gEJ1EYY8y5nToIC0bBT59ASB3oOxMuaux2VHmety0EVHU+MD+d7YnANl8GZYwJLNHHYxj+/mYm3dSQkB1zYcEDEHvCaRG0+Q/kL+B2iIYsJARjjDlfE5dsZfeOrRx++0lCjq+Gi5pAz0kQUtvt0EwqlhCMMX4TNmYBcQkJ3JRvGV8XmEX+Y4k8lTCAWTu78qslgxzHEoIxxm9W31aNwx/cQY1/vmdVYh0eYyh16jXgm26WDHIirypDichZM0NEZEKqktXGGPOvxARYNZGyM9pTJfZPRsffxhAdw7aE8hQvmJ+Q4umsemZcl5UFchak2TYF+B/QwqcRGWNyt30/OcXo/t4MYV15LOZmgktXYXazqsxav4sDJ2LcjtBkINOEICI3J39bIdX3KYrgLHVpjDGQEOsUolv5IhQqBb2mQp3reDZVMbqx19Z1Lz5zTudqIQxO/rNiqu9TnABG+zwiY0zus3uD0yo48BvU7+MUoytSxu2oTBZlmhBSrZ/8tKo+lD0hGWNyjbhTzqI1a1+HEpWg38dQ80q3ozLnyduZyukmAxF5RVXv8W1Ixphc4a/l8OXdcHQnNLkFOj3urFtgcq0ME4KIPAw8p6pxIrI0vUOABoAlBGPykn+OwtdjYPMMKHMpRM6H6q3djsr4QGYthET+rWBaERifZr/grLFsjMkrfpsHc++FUweg9UiIGA3Bhd2OyvhIhglBVVMngBGqujjtMSKyxy9RGWNylpPRTv2hn2dDaD3o9wFUusLtqIyPefsMYbGI1AR647QWooAP00sSxpgAogo/fAgLRzsPkDuMcVoG+YLdjsz4gbczlW8GNgMROMtntgc2i8gA/4VmjHHV0d0w80aYfTuUrQF3rIR291syCGDezlT+L1BHVXekbBCRS4AvcGYrG2MCRVISbHwHFj/utBC6TICmt0JQPrcjM37mbULYnzoZAKjqXyIS7fuQjDGuOfins67xrtVwSXu45hUoXe3c7zMBwduE8KGI3Ap8rKrHRKQU0Bf40m+RGWOyT2ICrHkVlj0DwYWg52Ro2A9SlZ0wgS+zeQhJ/DvsNOV/xZvy738QSd7/it+iM8b4X9QPTtmJqO+hVnfo9gIUr+B2VMYFmbUQ1uG0AjIiwPu+DccYk23iY2DFBFj5MhQpC72nw+U93Y7KuCizhNBbVXdn9mYR6ePjeIwx2WHXOqdVcPAPaNAPrhpnxehMphPTMk0GyaYBHXwWjTHGv2JPwpInYf0UKFkZBnwKl3VyOyqTQ3j1UDnN8wRjTG705xKYMxKO7YZmt0HHR6FgcbejMjmIt6OM0j5PKA10BQ77PCJjjG+dPuwUo9sy05lgNngBVGvpdlQmB/I2IbRX1dTr3u0EtojIXOAN34dljPGJX76Aef+F04eg7X3Q7gFnWKkx6fA2IYTImeORCwJ1gVo+j8gYc+FO7If5/4Vfv4QK9Z1nBRXrux2VyeG8TQg7cJ4hpGSFeOAv4IGsXExEmuIMVR2rqtNSbd8H/Jbq0JWqOiYr5zbG4JSa2DILvnoI4v+Bjo9BqxFWf8h4xduEsEhVr7qQC4nIdcCNwLF0di9U1cgLOb8xed6RnTB3JGxbClVbQo9XoVwNt6MyuYi3CeHVcx0gIt1VdW4mh2xQ1dkistzLaxpjvJGUBBvegsVPOKUmuj7vLGkZ5FUxY2M8vE0IE0SkNP92GaVnNJBhQlDVzBbTqS0iC4DiwC/AQ6p60MvYjMm7DvzuFKPbvc6ZT9D9JShV1e2oTC7lbUI4BLyL88v6MFAWqAGsTXXMhRQ/+RkYCZwAJgALRKSZqp4x90FEhgJDAapWtf/0Jg9LjIdVr8A3z0KBonDdm1C/jxWjMxfE24TwIzBcVb9P2SAiDYGBqnpf8uuJ5xuEqg5Jdd7HgeNAM5z5D6mPmwJMAWjSpIlNlDN5099bnLIT+36Ey6+Frs9BsRC3ozIBwNtOxnqpkwGAqm4BmqZ6fbcvAlLVUzitECvCbkxq8f84i9a81cFZ47jP/6D3e5YMjM9420IoJCK9cdZDUBEJAvoARS40ABHpABxX1Y3JrwvgzIT++0LPbUzA2LnaeVZw6E+4YiBc+RQULu12VCbAeJsQhgGfAe+JyFGgFBANXO+DGKoCbUXk1uRnBiOAbaTpLjImT4o94bQKNrztPCwe+Dlc2t7tqEyA8iohqOpGEbkUaAlUBKKANaoa7+2FRKQx8ALQEBgtIj1U9XpgKdAO+Fac6dAngGuycm5jAtLWRU4xuuN7ocWd0GGM8wDZGD/xtoVA8i/oFSJys6quyOqFVHUTEJHO9l3AkLPeYEweE308huHvb+a166pRfuUT8MMHUC4MbvkaqjRzOzyTB3idEFKJBKb7OA5j8ryJi/+g/K75FJ4yA5JOOIXo2v0X8hd0OzSTR5xPQrCBzsb4UNiYBZRIOMTY4KlcFbyRH+Iu5oH4UWxfWp3fO1gyMNnnfBLCNF8HYUyepcqGrlHkXzyGoMQ4no6/iZlB3enU4CKmd6vtdnQmj/E6ISQPNW0FxIpIG2C1qib5LTJjAt3h7TDnHkps/4btRRsy5MhA/g66iLiEJIoXzE9IcVu3wGQvb5fQvAyYgzNZ7AjOPIEdInKNqm7zY3zGBJ6kRFj3Jix9CiQfdHuRZ3+tR+saRejXrCqz1u/iwImYc5/HGB+TNOWC0j/IKTz3P+B9VU1Kbi30xSld0cXPMaarSZMmunHjRjcubcz5i/7NKTuxZwPUuNIpRleysttRmTxERDapapP09nnbZVRYVWemvEjuKpqVXGzOGHMuCXGw6mVY8RwUKAbXvwX1brRidCZH8TYhBIvIpam7h0Tkkiy835i8a+93TtmJ/T9B3Rvg6mehWHm3ozLmLN7+Qn8K2CIi64ADQHmgCdDLX4EZk+vFnYblz8CaSVAsFPq+D7W6uh2VMRnytnTFQhFpgPPcoDLwA3Crqu7wY2zG5F47VjqtgsN/QaNBTjG6QiXdjsqYTHk7yug+VX0BeNrP8RiTu8Uch8WPwcZ3oXR1uPlLuCTc7aiM8Yq3XUYPiEh9YCUwT1WtNLUxaf3xFcz9D5yIgpbDof3DUOCCK8Qbk228TQiv4Cxt2Ra4V0QqA1uBOaq63l/BGZMrnDoEC0fDjx9B+drQezpUTndUnzE5mrfPEJ4GEJFVQAGgK3AncDdgHaMmb1KFnz6FBQ84XUURD0KbeyF/AbcjM+a8ePsM4XacJNABZy2E+Tgrpn3jv9CMycGO/w3z7oPf58NFjaHHJAi93O2ojLkg3nYZtQWaA+8Bz9voIpNnqcJ378HXj0BiPFw5DloMg6B8bkdmzAXztstoQPJqZi2AW0SkOrAH5wHzSj/GZ0zOcfgv+PJu2PEtVG8LPSZCmUvcjsoYnwny5iARGZy83vH3wCYgFrgd+MiPsRmTMyQlwupJMLkVRH0P17wCg+ZYMjABx9suo8dFpDcQDvwMzAOuUtUNfovMmJxg/y9OMbq9m6BmF+j+IpSo5HZUxviFtwkhCPgYGKyq+/wYjzE5Q0IcrHwRVjzvzDDu9S7Uud6K0ZmA5m1C6K+qK1JvEJHrgZWqGu37sIxx0Z5NTqsg+heo1xuuHg9Fy7odlTF+59UzBODxdLYVBj7xXSjGuCzuNHz1MLzTCWKOQb+P4Ia3LBmYPCPTFoKIVE3+tpCIVAFSt5e/wyalmUCxfYVTjO7IDmgyBDo9AYVKuB2VMdnqXF1GO4CUJdV2ptl3AnjN1wEZk61ijjlzCr57zxk1FDkPqrdxOypjXJFpQlDVIAARma+qVsjdBJbfFzjF6E7uh1Z3O6UnrBidycO8nZhmycAEjpMHYOEopw5RSB3oOwsuauR2VMa4zpbANHmHKvz4MSwYBXEnof0YaH2PFaMzJpklBJM3HNsDc++FrV9B5aZOMbqQWm5HZUyOkmFCEJGhwBFV/Tgb4zHGt5KSYNNUWPQYaKIzp6DZUCtGZ0w6MpuHMAz4GkBExqV3gIh09EdQxvjEoW3w3jUw717nGcGw1VaZ1JhMZNZlJEAh4BjQMoNjHgaW+DooYy5IYgKsfQ2WPQ35CjrdQ1cMsLITxpxDZgnhHWC3iOQDEJHENPuFf+coGJMz7PsRvhgOUVugVnfo+jyUqOh2VMbkChkmBFV9VUSmABWAD4C+aQ4R4H0/xmaM9xJiYcVzsPIlKFwabpwGl19rrQJjsuBcE9NigZ0i0ltVd6fdn1wS2xh37V7vtAoO/g4NboKrnoYiZdyOyphcx6vidqq6W0Rai8jbIrIw+c9W6SWJzIhIUxH5U0Qi02xvKCJrRGSViMwREasmZs4t7hQsGA3vXOl83/8TuO4NSwbGnCdvV0y7GWc9hCScFdOSgI9FZIC3FxKR64D/4DykTr29APAF8JCqtsYpmveGt+c1eUf08Rh6v7mG6BMxsG0ZTG4B616HprfCXWuhRme3QzQmV/N2YtodQD1VPZSyIflT/Bzgf16eY4OqzhaR5Wm2dwESVXVZ8uu3gR0iUl5VD3h5bpMHTFyyld927Gb31FcJOTwPyl4GgxdAtVZuh2ZMQPA2IcSnTgYAqnpIROK9vZCq7slgV1Pgt1TH7RaR00Aj4Ctvz28CV9iYBcQmJHFl0AYWFZhK2UPHmZzYg9f39+JHSwbG+Iy3CeGAiDwKvAscAMoDkYAvVksLJU03EnAUCEl7YPLs6aEAVatWTbvbBKiVd9Vhz6wRXHFiOb8kVWOYjqJK3ZYs6Vbb7dCMCSjerph2J9AW2AWcxlkboU3ydl9Ibz7DWeMFVXWKqjZR1Sbly5f30aVNjqUKW96n/HttqXdyFc8l9ObGpHFsTqhG8YL5CSleyO0IjQko3pa/jgY6i0gloDKwW1WjfBRDNHBFmm2l8E3rw+RWR3fD3JHw52Ko0pwnuYOksjX5uFlVZq3fxYETMW5HaEzAyVK1U1X9G/jbxzFsINWkt+SlOovgjGYyeU1SEmx8BxY/7rQQukyAprfxZNC/jdmx19Z1Lz5jApi3XUb+tADILyLhya+HAJ/ZCKM86OBWmNYV5v8XqjSDO9dA89shKCf8NzUm8GXbeggi0hh4AWgIjBaRHqp6varGisi1wOTkeklHcB5Ym7wiMR5WvwrLx0NwYbj2dWfGsZWdMCZbeZUQRKQdcFxVt5zvhVR1ExCRwb7NZFxR1QSyqO+dshP7foDaPZxidMVD3Y7KmDzJ27b4HCDMn4GYPCY+BpY8CVPaw4l90Hs69JlhycAYF3nbZfStqn6YdqOIRKjqct+GZALerrVOq+DQVmjYH64ca/WHjMkBvE0I80XkYeBLzpxE9jRgU0WNd2JPOq2C9VOgZBUY8BlcZovuGZNTeJsQJiX/+VSa7bZAjvHOn0tgzkg4ttsZOdThEShYzO2ojDGpeJsQvlHV9mk3iojVGjKZO30Yvh4DW2ZCuZowZCFUbeF2VMaYdHibEK5Mb6OqXuXDWEyg+eULmPdfOH0I2v4X2t0PwVZuwpicytvSFfEi0g8YiDMyqS/wEPCIqloNAXOmE/ucyWW/zoEK9WHAp1CxvttRGWPOwdsFch4F7sIpR11aVY8AvwBv+jE2k9uowuaZ8Foz+ONr6PQ43LbMkoExuYS3XUadgHaqmigiPQFUdWpWVkwzAe7ITphzD/y1DKq2hB6vQrkabkdljMkCbxNCPlVNTP5eAUQkCKcIncnLkpJgw1uw+Amn1ETX56HJLVZ/yJhcyNuEsEpEFgPvAaVF5AagH7As87eZgHbgd/hyBOxeB5d1gu4vQ6kqbkdljDlP3iaEh4BRwCM46yE8DUwDnvNPWCZHS4yHVS/DNxOgQFG47k2o38eK0RmTy3k7yigBGJf8ZfKyv7c4ZSf2/wh1rnPWKyh21mqnxphcyOvy1yLSCWe4aUUgCnhfVZf4KzCTw8T/45SnXv0qFC0HfWZC7e5uR2WM8SFvh52OAqYnv/wJZ73j/4nIA/4KzOQgO1fDG22cbqKG/eCudZYMjAlA3rYQBgB1kucfACAiZYFvgAn+CMzkALEnnKUsN7wNparBwM/h0rMqmBhjAoS3CWFP6mQAoKqHRCTKDzGZnGDrIqcY3fG90OJO6DDGeYBsjAlYGSYEEama6uV8ERkLfIyzxGUZnOcJ9gwh0Jw+DAsfhB8+gPK14JZFUKWp21EZY7JBZi2EHTiT0FKPJXwozTEKjPdxTMYNqvDzbJh/P8QchXYPQLv/Qv6CbkdmjMkmmSWEdEtepyYiNjEtEByPcorR/TYXKjaEm7+ACnXdjsoYk80ySwjplrxOw+Yl5GaqsHkGfDUGEmOh85PQ4i7I5/VoZGNMAMnwJ19V41O/FpFmwCVAgVSbRwOX+yc041eHtzvF6LZ/A9XaQI+JUPZSt6MyxrjIq4+CIjIN6AL8ASSk2lXBDzEZf0pKhHVvwtKnQPJB95egUaQVozPGeD3s9AqgiqrGpd4oIo/4PiTjN9G/OmUn9m6EGlc5yaDkRW5HZYzJIbxNCKtxuori0myP9m04xi8S4v4tRlewOFz/NtTrZcXojDFn8DYhjAeWishO4ESq7Vdjq6blbHs3wRcjIPpnqHuDU4yuaDm3ozLG5EDeJoQPgb3Ab5z5DCHW5xGZCxJ9PIbh729m0o1hhGx8CdZMgmKh0Pd9qNXV7fCMMTmYtwkhQVWvS7tRRL7zcTzmAk1cspWgnasIeuNWiNsDjSOd4aSFSrodmjEmh/N2aMnnIpJe/QL7yJlDhI1ZQN3RH1Nr02N8UOApTsbEc1Pcw4Stu9qSgTHGK962EO4CxorICf59hiBAKDDMH4GZrFnXKwHmjqZ4/CHeSujKa9KH8PrV+LZbbbdDM8bkEt4mhKNAZJptArzky2DMeTh1EBaOptSPH7Ov0CVEnr6bX4NqEpeQRPGC+QkpXsjtCI0xuYS3CWGoqm5Iu1FE+vk4HuMtVfjpU1jwAMQch4gHeXJXOHVrFefpZlWZtX4XB07EuB2lMSYX8XZN5bOSQbI7gHt8F47xyvG/Ye698McCuKgx9JgEoZczOdUhY6+14nTGmKzxtnTF0gx2NcQSQvZJSoLv3oNFj0JiPFz1NDS/A4LyuR2ZMSYAeNtlVJEz1z0oBVwFvOqLIJJrJVVPs7m7qp70xfkDwqFtTjG6Hd9C9bZOMboyl7gdlTEmgHibEAar6trUG0TkVeADXwWiqhG+OldASUqEtZNh6TjIFwzXTIRGN1vZCWOMz3n7DGFtOpvLAPV9G445w/5f4Iu74O/voGYX6P4ilKjkdlTGmADl7TOEv9JsKgiUA17wVSAi8gZQBzgJTFDVvLsaW0IcfPuC81WoJPR6F+pcb60CY4xfedtldAwYmep1HLBTVf/2URy/AktVdUPyjOhlItJGVbekPkhEhgJDAapWreqjS+cwezY6JaoP/Ar1esPV46FoWbejMsbkAaKq5z5IpLaq/poN8aRc70PgsKpmOAu6SZMmunHjxuwKyf/iTjnPCdZOdrqFur8ENa9yOypjTIARkU2q2iS9fRm2EERkdkpBu+xMBsl24XQf5Q1/fQNz7oYjO6DJLdDpcShUwu2ojDF5TGZdRhHJ8w8ESGlGpHRip7xWVe14oUGIyAOqOiHVplDAV91ROdc/R2HRI/DddGcIaeQ8qN7G7aiMMXlUZglhi6p2SLtRRC4F3gFq48xU9oV7RWSaqkaLyMVAT6CHj86dM/02H+bdCyf3Q+t7IOJBCC7sdlTGmDwss4Rwc9oNIvIf4ClgHtBLVQ/6KI7ngdkikgAUBYar6jc+OnfOcvKAU3/o588gpA70nQUXNXI7KmOMyTghqOrulO9FpBYwFbgUGKKqH/kyCFV9HicpBC5V+OEjWDjKeYDcfozTMshfwO3IjDEGOMewUxEJAkYDjwALgJ6qGp0dgQWUY3tg7n9g69dQualTjC6klttRGWPMGTIbZVQfeBenxtAQVX0/nWPGqOpY/4WXyyUlwaZ3YdHjoInOnIJmQ60YnTEmR8qshbARZ1TRO0ANEXk0zX4BBgGWENJzaBt8OQJ2roJLIuCaV6B0dbejMsaYDGWWEH7mzNnJ6bnWZ5EEisQEWDMJlj8D+Qo63UNXDLCyE8aYHC+zhPDEuUb6iMgTPo4nd9v3o1OMLup7qNUduj4PJSq6HZUxxngls1FGn5/rzd4ckyckxMKK52DlS1C4NNw4DS6/1loFxphcxdvidiYju9c7xegO/g4NbnJWMStSxu2ojDEmyywhnK/Yk7B0LKx7A0pWhv6fQo1ObkdljDHnzRLC+di21FnO8uguaHobdHoMChZ3OypjjLkglhCy4p8j8PUY2Pw/KHsZDF4A1Vq5HZUxxviEJQRv/ToH5t0Hpw5Cm/9A+GgILuR2VMYY4zOWEM7lxH5YcD/88gVUqAf9PoJKDd2OyhhjfM4SQkZU4fsPYOFoiP8HOj4Kre6GfMFuR2aMMX5hCSE9R3fBnJGwbQlUae7MNi5f0+2ojDHGrywhpJaUBBvfgcWPOy2ELs9B01shKMjtyIwxxu8sIaQ4uNWZYLZ7LVzaAbq/DKWruR2VMcZkG0sIifGweiIsf9ZZwvLa150Zx1Z2whiTx+TJhBB9PIbh72/mjY75KbP4Xtj3A9Tu4RSjKx7qdnjGGOOKPJkQJi/6ifDdkyn5v3lQtCz0ng6X93Q7LGOMcVWeSghhYxZQPnEf7wU/y6X5o/goIZyxh/oTO6sAv9syP8aYPC5PDZ/59oH2NK1fh91SgYFxo3lUhtG+YU2+HdXe7dCMMcZ1eaqFEFKiEEUKFWZw3P0UyBdEXEISxQvmJ6S4laAwxpg8lRAADp6MpX/zavRrVpVZ63dx4ESM2yEZY0yOIKrqdgznpUmTJrpx40a3wzDGmFxFRDapapP09uWpZwjGGGMyZgnBGGMMYAnBGGNMMksIxhhjAEsIxhhjkllCMMYYA+TiYacicgDY6XYcXioHHHQ7CD8K5Puze8u9Avn+LuTeqqlq+fR25NqEkJuIyMaMxv0GgkC+P7u33CuQ789f92ZdRsYYYwBLCMYYY5JZQsgeU9wOwM8C+f7s3nKvQL4/v9ybPUMwxhgDWAvBGGNMMksIxhhjAEsIfiMiwSIyUkSWi8g3IrJGRDq6HZeviUgNEYkXkQi3Y/E1EblVRFaJyEoR+UFEwt2OyRdEpLaILEu+r80iMsrtmC6UiDQVkT9FJDLN9obJP3urRGSOiJR1KcTzlt69iUh1EXlXRJaKyFoReV9E0p1bkBWWEPznIuAeoKeqhgOPAl+IyEXuhuVzTwJxbgfhayJyI9ARaKeqbYCXgAruRuUz7wGrk++rEzBKRK52OabzJiLXAf8BjqXZXgD4AnhIVVsD3wFvZH+E5y+jewMigaOq2gFoCSTigwfNlhD85wTwqKoeA1DVRUAM0MrVqHxIRJoCJ4EDbsfiB48CT6pqIoCqTlXVD12OyVfqAGsAVPUQsBW4wtWILswGVe2H8zOXWhcgUVWXJb9+G7jeF5+ks1FG9/Yd8BqAOiODPgA6X+jFLCH4iaoeUtUZKa9FRIACBNYvzyeSvwKKiIQAtYGGyV0r34rI7W7H5UPzgGsAROQSnASxztWILoCq7slgV1Pgt1TH7QZOA42yIy5fyOjeVPVLVd2WalMhfFCmI8+tqeyicJzaSyvcDsQXRKQL8LOq7nFyXUCpDghwHU6XSgiwXkSOqeoHbgbmI7cAX4rINqAMcK+qLnU5Jn8I5eyulqM4/56BpjvJLYYLYS2EbCAihYCngUhVTXI7ngslIkHAKOAZt2Pxk4I4PxuvqmqiqkYBM4Ah7oblM58Ba1T1UqA+cK+I5JpPzVmU3kSrgPoEIyKtgEuBly/0XJYQ/Cy5q2gK8JKqbnI7Hh/pB3ylqofdDsRPjiT/uT/Vtj1AZRdi8SkRqY3T6nkZPN0oi4D7XQzLX6KBUmm2lUreHhBEpBowHuilqvEXej5LCP73ArBeVT8WkYIiUtXtgHygLdA9eUjtcpzRNy+LyBfuhuUzW3H6mlN3LZQH/nYnHJ8qkPxn6l8e8UAJF2Lxtw1AWMoLEakCFAEC4oOZiJTDablGqup+EakqIgUv5JyWEPwoeXx3fmCaiBTDadbl+m4HVb1dVVuraoSqRgD7gJGq2tPl0HxCVWOB6Th97YhIUaAPznDN3O43YC9wE4CIFAd6AIH4DGEBkD/V/JEhwGeqmusHdiT/PvkUZzRcdPLrO4CKF3Req2XkHyJSE/g9nV1PqOrj2RyOX4hIM2AC0ALnF81nqvqku1H5RnISeAO4HEjA+eF7TgPgB0ZEmgAv4vSlFwMWAw+qaoKrgZ0nEWmM0xJviPPh5BdVvT553xXAZJxx+kdwPk0fcinULMvo3kRkHPBQOm+5WFV3nPf1AuD/tzHGGB+wLiNjjDGAJQRjjDHJLCEYY4wBLCEYY4xJZgnBGGMMYAnBGGNMMksIxviJiLwqIkfTLtpiTE5lCcEYP1HVEcAWt+MwxluWEIwxxgC2HoIxPpVcFuINnNXxNhBgpZZNYLMWgjE+kryG72zgheT1it8DmrsblTHes4RgjO+0xCmZ/RGAqm4B/nAzIGOywhKCMb5TETiqqomptgXqIkImAFlCMMZ3ooBSIpL62VxZt4IxJqssIRjjO2twlmfsAyAiDYHabgZkTFbYegjG+JCINOXfUUY/4yywUw54QFW/dDM2Y87FEoIxxhjAuoyMMcYks4RgjDEGsIRgjDEmmSUEY4wxgCUEY4wxySwhGGOMASwhGGOMSWYJwRhjDAD/B7HN4/fIxgTeAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYsAAAEMCAYAAAA1VZrrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/MnkTPAAAACXBIWXMAAAsTAAALEwEAmpwYAABB5ElEQVR4nO3dd3gU1dfA8e+hJSpg6EUCKAhSVMQAUpNQpIMgICIoNhQr8rMXEBUbFkRsqIig4GsBqYIgoah0UREE6RhaQqiChJTz/jGbNQkpG9jNJOF8nicP7J3ZmbMpe3bu3HuuqCrGGGNMVgq5HYAxxpi8z5KFMcaYbFmyMMYYky1LFsYYY7JlycIYY0y2irgdQKCULVtWq1ev7nYYxhiTr6xZs+aAqpZL315gk0X16tVZvXq122EYY0y+IiI7M2q3bihjjDHZsmRhjDEmW7maLESkkYhsEZGBmWwfISI70rWJiIwSkVUiskZEBuRGrMYYY/6Ta/csRKQH0Bs4ksn2CsAdQEK6TXcBVwNNgNLAehH5TVV/D2C4xhhjUsnNG9yrVHWaiCzKZPszwHs4CSO1u4A3VTUZOCAis4A7gfvPJIjk5GSio6M5fvz4mTzdGJNHXXDBBVSpUoVChax3PRByLVmoanRm20SkJlAZ+JpUyUJEgoArgI2pdt8A9DrTOA4cOICIULt2bfulMqaASE5OZvfu3Rw4cIDy5cu7HU6BlFfeLZ8DhmfQXhYnxtRdV4eBDH8bRGSQiKwWkdWxsbEZnujw4cNUqFDBEoUxBUihQoWoUKECR45k2Mt9Tok5epI+Hywj5thJvx7X9XdMEQkDElR1XRa7pa+jLhnupDpOVcNUNaxcudPmlACQlJRE0aJFzyxYY0yeVbRoURITE90Ow10nDrJl4n1s3BHNmAWb/XrovDApbwRwbybbDgDJQEiqthAg5mxOKJJhrjHG5GPn9N+1Kg8Oe5anC42nEcdpJFX5bMX5fLZiF0FFCrHphY5nfQpXk4WIlABqAhM8P+gQoKLnJvj/qep7IrIOqA2s9DytLrAq96M1xpg86Ng+mP0/3io8i13Btbj9+O38nhxKcNFCtK9Xkac61/HLaVzthlLVY6paW1UjVDUCGALs8zx+z7Pb+8BAz3yLMkBn4CN3Ig68n3/+mXbt2tGqVSuaNWvGDTfcwPbt290O6zTjxo2jevXqDBw4MNN9rrjiCrZs2ZJ7QQVAp06dWLRoUcDPc/LkSUJDQzlx4kTAz5VTO3bsoG7duvn2+AWWKvwyCcY2hi0LoN1zfFhrHOsSQwkqUoj4xGRKBBWhfIlgf51Pc+ULZ67EIpwb1BuBqem2DwN+BU569mvsaRdgFM7VxBpggC/nu/rqqzUjGzZsyLA9L4iKitLq1avrpk2bvG3ffPONVq5cWXfv3u1iZBkbPny43nLLLZluP3TokPf/27dvV+fXLTBuueUWHT58uN+Pe+TIEU1OTvb7cTOS+vuV1wQ6ttTH/+STTzQ8PPyMjpOX/779Km6b6oSuqsNLqo7vqHpgi6qqDpq4Sp+atk7X7z6iT01bp4MmrsrxoYHVmsF7am4OnV0DRGSx/TmcUVHp2xV4JHCR5UzM0ZPcN2UtY/td5b+MjTP0b9CgQTz55JPUqlXL296zZ0/+7//+jyeffJIJEyb47Xy5ISQkxO0QzlrJkiVz7Vx5+fsV6Njy8mvPU5KTYMUHsPB5kMLQ+Q24+lbwjO78YECYd9cXrqvv11O7Phoqvxnzw2ZW7Tjo95EGa9euZfPmzbRr1+60bR06dODbb78lOTmZe+65h5CQEJ555hl69+5NrVq1ePLJJ9PsP2rUKK655hpatmzJ/fffz6lTpzI974svvki9evW49tprefnllxERIiIi+P7777nsssuIiIgAYNq0aRl2O/3777/ccsstNG3alJYtW3q7zP73v/8REhLChAkTOHLkCH379gUgIiKCiIgIkpKSToslNjaWTp060bhxY3r06MEdd9xBxYoVee455zPEc889R+vWrWndujVdunRhz549ALz11lvMnTuXCRMmEBERwccffwzAmjVraNWqFeHh4bRp04aNG53pOsnJyQwePJgWLVrQqlUr7rjjjgwnaY4aNYqKFSvy7LPPAvj0vU+xa9currnmGkSECRMm0Lp1a+rVq8f69et5/PHHCQsLo1OnTpw86QxvvOmmmwgODmbRokWcOnWKiIgIRIR33nmHzp07U6JECV599VUaNGhA9erVGTVqFBEREd4h4Js3b6ZDhw7e7svvvvsOgJUrV2b6nPR++eUX78+nWbNmvPvuuwC0adMGEWHHjh2nva5rr72WoKAgduzYQUxMDL1796ZVq1Y0bdqUhx56iH///Zebb77Z+9oAunfv7j1e+uMvXryYl19+mV9//ZWIiAjuv9+ZeztixAiaNm1KZGQkN9xwA3v37s3wNRRoMRthfHuY9wRUbwH3LodGt3sTRcBldLlREL783Q1V66k5Wu2xWad91XpqzhkdL70vvvhCAT116tRp2+bNm6eA7t+/X1VVw8PDtVOnTpqcnKx79uzRIkWKeLupPvvsM73sssv0+PHjmpycrL1799bnn38+w3POnj1bK1asqHFxcaqqOnTo0DRdRem7A9J3Ow0fPlzLlCmje/bsUVXVkSNHatOmTb3bw8PD9ZNPPlFV37qhevfurYMGDVJVp/vn4osvTnO+MWPGeLuEPvnkE+3fv793W/puqMOHD2vZsmX1hx9+UFXVWbNmaa1atTQpKUlnz56tHTp08O573XXX6fbt2zOMKf1xs/rep5fymr/55htVVX3wwQf1kksu0Z07d2pycrJeeeWVOmXKFO/+1apV06ioKO9jQEeMGKGqqpMnT9Y1a9ZoVFSUFi1aVOfPn6+qqg8//LAmJCRo7dq1vd/rzZs3a4kSJXTLFqdrIqPnpJfy/Vq0aJGqqu7cuVPr1q2bJpaU71HK6/r0009VVfX111/XPXv2aLt27fTZZ59VVdX4+Hi96qqrvM/J6LWl/p6nfpz+9279+vVap04d789+yJAhaY6VWoHshkqIV130iupzZVVfrq762/+pBrBrlEy6oezKwkdLH42kW4PKBBd1vmXBRQvRvUFllj4W6Uo87du3R0SoVKkSZcqU8X5KmzBhAn379uX8889HRLjxxhuZNGlShsf46quv6NSpE6VLlwacT7c51bx5cypVqgTAgAEDWLZsGbt27crxcZKSkpg2bRr9+/cHnO6fLl26pNknNDSUyMhIWrVqxejRo1mzZk2mx5s1axbFixendevWAHTu3Jl9+/axYsUKSpUqxbp165g/fz7JyclMmTKFqlWr+hxrZt/7zKRcLdavX5+QkBCqVq2KiFC/fn22bduW5XO7d+8OwI033kjDhg0Bp6xF27ZtAefqZ8WKFWzbts37vatZsyZNmjTh888/9x4n/XPSmzVrFiVKlCA8PByAqlWrMm7cOJ9iGzp0KMnJycyfP59bb70VgGLFijF+/Hgym++UEyVKlGDfvn1MnTqVhIQEXnnlFVq0aHHWx80Xdv8CH0ZC1Eio0xXuXQlX9AEXhglbsvBR+ZLBlAgqQnxickBGGtSoUQPA27WS2u7duwkJCaFs2bLettR96cHBwd6upujoaCZPnuztTnjllVe83Q59+/b1tu/bt4+9e/emOWZK0siJUqVKef9fpkwZgDPqIoiNjSUxMTHTeDZv3kyfPn0YNWoUS5YsYfTo0VmOHIqOjubgwYPe1xsREUG5cuWIi4ujadOmjBs3jldeeYVq1arx2muvpQyy8Elm3/vMlChRAoAiRYp4/5/yOLvnXnjhhdm2RUdHU6pUKYoU+e8WZLly5YiOjs70OelFR0ef9sbevHlzn2NLOVfqYzRo0IALLrggy2P4IjQ0lNmzZzNp0iRCQ0N54oknsv2+5XunTsD3z8BHbeBEHPSdAr3GQ/GzT75nKi9Myss3DvwTz01NqtGvcVUmr9xFrB+n0zds2JCaNWsyf/587rgjbS3FefPm0atXL59KlISGhtKuXTseeeS/MQEHDhwA4Isvvkizb6VKlUhdFiUuLi7N9mLFihEfH+99fPjw4dPOd/DgwdPOk3KlkRPlypWjSJEixMbGUqdOndPiWbt2LSVLlqRRo0YAJCSkL06cVmhoKFWqVEkz7PXo0aMEBwdz5MgRIiIi6NSpE1u3bqVDhw5cdNFF3k/F+U1oaCiHDh0iMTHRmzBiY2O57LLLcnSM9CVy1q5dy5VXXunz713KeVOu0rZt20apUqUoVapUmt+ljH6PsnLixAnq1q3Lt99+y759++jZsyevvPIKI0aMyNFx8o0dP8KM++HgNmh4C1z7PARnnexzg11Z5MAHA8J44br61K1ckheuq59m5MHZKlSoEB9++CEvvvgimzf/d/N8+vTpLF++nBdeeMGn4wwcOJCvvvrKe+M0KiqKu+66K8N9+/Tpw5w5c7xvyl9++WWa7RdffDGbN28mPj6ekydPEhUVddoxlixZ4r2SmDhxIk2bNs2wSyflE/WJEyd4+eWXWb58eZrthQsXpmfPnt4us6NHjzJ37lzv9po1a3Lo0CH++usvgDTbUo5/4sQJjh8/zk033USXLl04cOAAq1Y58zePHz9OZGQkR44cYdq0ad4ulho1alClSpUMb7jnF02aNKFmzZpMnjwZcN6kV6xYkaNuxS5dunDs2DGWLFniPcbgwYN9rqFWuXJl2rVr5x2xFx8fT58+fbxXABdffDF//PEHAHPmzMnyWCk/S4Drr7+en3/+meHDndJxFStWpHbt2vn655Wpk0dh1kMwoTNoMtw8A7qNyROJArAb3HnNkiVLtHXr1tqyZUtt2rSp9u3bV3ft2uXd/sgjj+iFF16otWvX1p9//lkHDx6sQUFBeuWVV+r69etVVfW1117Txo0ba2RkpHbv3t17YzwjI0eO1Dp16mj79u11zJgxp92E7t+/v9atW1dvuukmve+++7RChQr6wgsv6AcffKDVqlXT6667Tvv06aNNmjTRFi1a6NatW1XVuVmeEuesWbNUVbVfv3569dVXa9u2bfXEiROnxRITE6MdO3bUsLAw7dWrlw4ePFgHDhzo3f70009rtWrVtFu3bjpo0CANCgrSAQMGqKrqzz//rLVr19ZGjRrp559/rqqqq1ev1vDwcG3VqpW2bNlSZ86cqaqqGzdu1E6dOmlkZKQ2atRIb7/9do2Pjz8tnldffVUrVKig1apV048++sin732KuLg4bdKkiQLarVs3XbFihdauXVsvvPBCHTZsmH7wwQfeY3/++efar18/77FWr16t7dq1U0CbNGnivUm/fv16vfLKKzUoKEjDw8O9AxNUVbds2aIdOnTw/t7MmTMn2+ekl/r7FRkZqevWrVNV1datW3tjiY6O9r6u8PDwNK97//792qtXL23ZsqU2a9ZMv/rqK++2pUuXaq1atbRNmzY6YcKENMdLf/yDBw/qVVddpc2aNdMHHnhA9+7dq71799ZWrVpps2bNtEePHpnO+8jrf9+Z2jRX9fU6qs+GqM59UjX+uGuhkMkNbtEc9NXmJ2FhYbp69erT2v/8809vN4dJa8eOHVx88cU56r/3p8OHD1OyZEnvp9l7772X4sWL88orr7gSj8l/8t3f9/E4mPs4rPsSytWB7mOhiv96LM6EiKxR1dOCsG4ok2e89tprzJ8/H3ASx6xZs2jfvr3LURkTAKqw7mt4pxGsnwYRT8BdS1xPFFmxZGEAZ8RV6olzbow2CQ8PZ/jw4URERNCmTRuGDh3qHfpqTIFxdA9MuRG+uR1KVXeSRMTjUKSY25FlyUZDGQAuuuii024657Z27dplOIPdmAJBFX751BkSm5QA146EawZDocJuR+YTSxbGGBNoB7fBjAdgx1Ko3tIZ5VT6ErejyhFLFsYYEyjJSbD8PVj4AhQuCl3fcuZO5MOFmixZGGNMIOzfADPug91roFZH6PIGlKzsdlRnzKdkISK1gGuAycCFwGtAYeBJVY3O6rnGGHNOSTwFS193voJLwvUfQ/3r8+XVRGq+Xlm8DnwPKPAyTsL4FWfFug4BicwYY/Kb6DUw/V6I/RMu7wMdXoYLyrgdlV/4miyCVfVtETkP6ApcqqrHRGRxAGM7pzz33HO8++673H333d71E3LLkiVLGDJkCEWKFKFu3boEBwfTrFkzbr755lyNI719+/Zx8803U7ly5dMWfjp48CADBw7k4MGDJCYm8u6773qrsqY3YcIEJk6ciKpy7NgxHn74Ye8wYbds3ryZvn370rVr19N+3g0aNEizGFDNmjX56KOMVxJOv++xY8dISEjg999/D0DUJlOnTjiVYZe/CyUqQb8voVbBmiPka7IoLiJFgH7AfFU95mnP39dVeciwYcOyLVd9JiIiIhg4cGCWa2U/9dRTPPzww/Tr14/33nuPAQMGEBz8XzXd6tWrexcWyi3btm3jrrvuSlOFNrV77rmHq666ihEjRhAVFUX37t3ZsmULQUFBp+374IMP8scffxAaGsr69esJCwujVq1amSaXQEup9ZXZa2vQoIHPqyKmXqQI4M033+To0aP+CNP4avsSp/DfoR0Qdhu0HeF0PxUwvk7K+wTYB7wEvCgiZURkKrApYJGZXBMdHU3lys6Nt8GDB1O8ePE05a7dULJkSWbOnEnt2rVP23bw4EG++uorbr/9dgAiIyMpVqwYs2bNyvBYzz77rLcqar169ahXrx4//PCDX+NdtGiRz8m0WrVqTJ8+/Yyq86aXOlEATJ482buuhQmwk0ec4bCfdgUpBANnQ5c3C2SiAB+ThaqOA6oBVVX1T+AI8BDwYABjOyfFxMTQq1cvGjduTOfOnb1lv8EpVd60aVPCw8Pp2rWrd+2LEydO0KdPH8LDw2nRogUPPfQQAE888QS//vorL7/8MhEREcyePfu08/Xs2ZO9e/cyZMgQOnbsyKRJk9Isn3rrrbeyb98+hgwZQkRERJYLDgG89957lChRgjp16vDjjz8SGxtLw4YNufjii1m3bp3P34eyZcumubpJ7ZdffiEoKChNddu6deuSUS0wwPv9SHHy5MkMF+VZt24dderUISgoiLFjxzJjxgzKly/vXRDIXypVqkThwplPxNq7dy89evSgRYsW9OvXL9vFlVJs2rSJokWLetdGMQG0cQ680wTWToJmD8DdPzlLnRZgOfn4WAa4UUQuwLnJXV9VT3/3yW++exz2+f4mdkYqXg4dX/Zp14ULF7Jq1SpKlCjBoEGDeOCBB5g8eTLbt2+nV69erF69mtq1a/POO+9w8803s2DBAiZMmECZMmX48ssvSUpK4pprrgHgpZdeYtmyZVl2Q02dOpXq1aszevRo7yfjrVu3et+gPvnkE6KiotJsP3nyJDVq1GDatGk0btw4zfEGDx7Mn3/+ycmTJ72rmd100000bNiQyy+/nAkTJmTZxZJ6/YnM7N+//7TFfEJCQoiJicn2udu2bSMuLo7rr7/+tG2XX345y5Yto27duoSGhnLllVfSrVu3TO8XBErNmjUZNmwYFSpUYOzYsbRs2ZJNmzZx/vnnZ/m8zz//nAEDBuRSlOeof2Lhu0dh/VQoXw/6ToaL3OnOzG2+Dp3tDnwM/AhcArwA9BKRy1XVt3dB45P27dt7134YMGAAbdq0YdKkSUyePJmwsDBvt0y/fv2477772Lt3L6VLl2bp0qWsWLGCJk2asHhxYMcdFC1alDp16mS6+trNN99Mu3btGDNmDMHBwURFRTF06FCAbO+f+EoyGIaYXbVcVeXBBx9k3LhxaVasSy0kJIT33nuPu+++m+bNm/Pee+9lerzUie/w4cPs2LEjTVeUL4kvI++88473//feey8jR45k5syZ3HDDDVk+7+uvv+bHH388o3OabKjCuq/gu8cg/hhEPgXNh+T5ek7+5OuVxSM4VxL7RCRKVU8Bt3pGQ+XvZOHjJ/7ckn6Z0oSEBA4cOEB0dDQbNmxI82ZUrVo19u/fT9++fUlMTOTBBx8kLi6OoUOHMnjw4IDFWLhwYRYsWJDp9rCwMCpXrsyMGTOoXbs29evXz/DN/UyVL1+eI0eOpGk7fPgw9erVy/J5Tz31FJGRkXTt2jXL/bp3786YMWNQ1SzXkE6d+BYtWsSzzz57xgkiMyJClSpV2LlzZ5b7LVu2jFq1ap3R0rgmG0eiYdZQ2DwPqjSCbmOhvO+rEBYUviaLJFXdF9BIDHD6MqVFixalbNmyhIaGEhYWlua+w6FDhyhZsiQHDhzghhtuoH///qxdu5a2bdty2WWXERkZ6cZLAJyrookTJ3LZZZelWa7UH91QDRs25OTJk/z999/eG9cbNmzI8oplzJgxJCQkeK9wNm/ezKWXXprhvn/++SehoaHMnTuXefPm5WqZ9D/++INdu3bRqVMnb9v+/fu9AxAyY11QAZCcDGs+gfnDQZOcORONB+Wbwn/+5utoqAMiMlxEQgFEpLSIPARk30mciog0EpEtIjIwVVt1ERkvIgtFZLmITBGRcume9z8RWeP5euS0Axcgc+bM4dgxZ2TyxIkT6dWrF4ULF+bGG29kxYoV3k+YMTExREREkJyczNixY71J5PLLL6d06dLeZSdTlqjcvHlzmnW5cyLlGFFRUbz11lskJSXRtm1bNm3KfDBc//79mT9/PuvWrUvziX/gwIEsWrQo0y9flClTht69ezN+/HgAFi9ezKlTp+jcuTPg3PdJPY/iiy++YPHixQwbNox//vmHf/75h5EjR2Z47OTkZIYPH86YMWN4++23ufPOO3N1KOqBAwd46623vGuMf/PNNxw/ftybPNK/NoDExETmz59Ply5dci3OAi9uqzPKafZQ557E4J/zVYXYgMho+bz0X0A5nBncyZ6vJGAuUM6X53uO0QOnXMgaYGCq9meBNzz/F+AzYFqq7R2AjUCw52sj0Dm78+W3ZVVHjBihFSpU0Ntuu027du2qYWFh2rFjR42NjfXuM2/ePG3WrJmGh4drZGSkLlu2TFVVly1bpq1bt9bIyEi9+uqr9fHHH/c+Z+rUqVqrVi1t1KiRLly48LTz9ujRw7uc56uvvqoTJ07UatWqeZdPVVV9++23tU6dOtqkSRP9448/9N9//9VKlSrpihUrsnxNbdq00TfeeOOMvh+JiYkaHh7ujSU8PFx37tzp3R4XF6ddu3bV5s2b6zXXXKNr1qzxbvvyyy+1QYMGqqr6zz//aLFixRSn+oD365ZbbjntnDExMXr11VdraGiorl27Vl966SUtUqSI1qlTR9euXZtlvFFRURoeHu7Ta4uOjtbw8HDvsqrh4eHeZV3j4uL0gQce0KZNm2qLFi20ZcuWab7PqV9bitmzZ+udd97p07kLurP++05MUP1xtOrz5VVfDFVdM1E1Odk/weUT+GNZVRGpDFQB/gb2q2pyDp5bRVWjRWQRMEFVJ3jauwHrVXWr53EX4AtVLe55PA1Yq6rPeR4/AzRW1Sw7nm1ZVff169ePN954g4oVK7odijlHnNXf9751MP0+2Psr1O4MnV+Hkmc/Fya/OatlVUXkLQBV3aOqK1V1L/CliLzpawCaScFBVZ2Rkig8goEDqR43wrmaSLEByLtrD57jDh48yOzZs4mLi+PUqVOWKEzelxjvlBAfFwFHd0PvCdD383MyUWTF1xvcl6dvUNVeIrLUz/EAdAHeSfW4As4kwBSHgfIZPVFEBgGDgDQTtkzuiY+PZ/DgwVSoUOG02cXG5Dl/r3SuJg5sgitvhPYvwvk2oiwjWSYLEYnC6eNtICIL020+P7vn55SINANqAHem2+RTX5k6M83HgdMN5c/YjG8qVarErl273A7DmKydOg4/PA8r3oeSF8FNX8OltqRvVrJ7s5/g+bcS8Gm6bceA9AnkjIlINZw5G71UNSHVphggJNXjECDWX+c1xpxjtkbBzAfg8C5odCe0HQ5BGU/SNP/JMlmo6qcAIrJdVZek3y4iIf4IQkTKApNwRkntF5GqODfQ44FVQOpqcnU9bWdMVf06ScwY475sB+v8ewi+fxrWfgala8Ct30G1ZrkTXAHgayHBJeC8qYtI1ZQvYM7ZBiAixYFvgGFAjOfx3ThXMwDv49SkChaRYJwy6e+f6fmCg4OJi4vL/hfLGJNvqCpxcXGZFp/kz5lO4b9fp0CLh2DwT5YocsjX2lDNgCk4w2ZTfyT3+R1XRK7GWXGvAfC4iHRT1Z7AE0ArICrdU8YBqOpcEakH/ORpH69nUcCwSpUqREdHExtrPVnGFCTBwcFUqVIlbeM/MTDnEdjwrVPQs9+XULmBG+Hlez7Ns/DMjbgFZ35EpIgUxZks10hVhwU2xDOT2TwLY8w5QBV++wLmPg4JJyD8MWj+IBQu6nZkeV5m8yx8Hc10SlV3ikhhAM8N6Jkico8/gzTGmLN2+G+YNQS2LIDQJk7hv3K13I4q3/M1WRTy3Mw+6KkJNQ9oAmRcic0YY3JbcjKs/hgWPOtcWXR81RntVMjXEngmK74mi7FAJ+BpYAbOvYdDwK1ZPckYY3LFgc3OOti7lsElkdD1LShVze2oChSfkoWqfpvq4SWeqrBxOakNZYwxfpeUAD+/DYtehqLB0P1daNAPbGi83/k6GuprVe2V8lhVbSiRMcZde39zSnXs+x3qdINOr0GJCm5HVWD52g3VWUS2ZdCuODOs5wEveSbRGWNM4CSchCWvwo+j4fwy0Gci1O3udlQFnq/J4hWcmdNTgINAGaA3sBbYhjNRbjQQuLU8jTFm13LnaiJuMzS4Ca59wQr/5RJfk0VjVe2UusGzzsRMVX1VRKby36Q5Y4zxr/hj8MNzsPJDuDAU+k+Fmm3cjuqc4muyqCIiRdMV+CsGVANQ1WQRsS4oY4z/bVkAM4fAkWhnDew2wyCouNtRnXN8TRYLgZUi8jXOwkTlgF7AAk+9pmHAycCEaIw5J504CPOegt8mQ5lL4ba5UPUat6M6Z/maLIbiFPfrhVPgby9OMb8PPcf4AfggEAEaYwq+mKMnuW/KWsb2u4ryJYJhw3SY/TCciIOWD0OrR5yhscY1vs6zSAbe9Xyll4STLIwx5oyM+WEzq3YcZPx3y3hcP3aqxFa8Avp/A5WucDs8g59XujPGmJyo/fR3xCcmA0qvwksYvH4S8STwdvKNPHznWChsb1F5hf0kjDGuWfpoJO9+u5B2W1+iuaxjtdZm3iVPcWfP9pYo8hj7aRhj3JGcRPkNE3hix7MkoIxIuo1PE1vTr2R1576FyVN8LfdxlaquTdd2P7BAVf8MSGTGmIIrdpNT+O/vFWw+rxFzL36c3i0ak7ByF7HHbGBlXuTrlcXrQOt0beuAjwFbm9AY45ukBPhpNCx+FYpdAD0+oP4VN1DfU/jvhevquxufyVSWyUJEWnn+GyIiLUm7pOp5wIWBCswYU8DsWQvT74f966BeD2e9ieLl3Y7K+Ci7K4tPPf9WBCam23aUjIfSGmPMfxL+dUqI//w2XFAWbvgc6nRxOyqTQ1kmC1W9GEBExqvqbbkTkjGmwNjxk3Nv4uBWuGoAXPs8nFfK7ajMGfBpvcHMEoWIPOHfcIwxBcLJozD7fzChEyQnwIBvoftYSxT5WKZXFiLSH5jsKRI4PpPdOgAvBSQyY0z+tHm+U/jv6G645h5o/bRzM9vka1l1QzUHpgIngEhgQgb7WKVZY4zjxEGY+wT8/gWUuwxunw+hjdyOyvhJpslCVVMvZPSMqn6Wfh8R2RqQqIwx+YcqrJ8Gcx6Bk4eh1aPQ6mEoEuR2ZMaPfC0k+JmIlAI681/V2dkZJZCsiEgjnNX2XlDVCanaGwDvAck4K/ENVNU4zzYBXgUicO6xjFbVSTk5rzEmQI7ude5NbJoNlRrAzdOhos2VKIh8ncF9LfA1znrbcUBZ4B0R6aWq8308Rg+cpViPpGsvBkzHSRBRIjICp/x5b88udwFXA02A0sB6EflNVX/35bzGmABQhbWTYN7TkBQP7Z537k9YPacCy9ef7KtAe1VdltIgIi2Ad4ArfTzGKlWdJiKL0rV3BJJUNcrz+CNgh4iUU9VYnGTxpqdM+gERmQXcCdzv43mNMf50cDvMfAC2L4FqLaDbGChTw+2oTID5miwOpU4UAKr6o4gc9vVEqhqdyaZGwMZU+/0tIieAhp7EckXq7cAGnEWYjDG5KTkJVnwAC58HKQxd3oSGA6GQTyPwTT7na7JYICLtVXVeSoOIdAR+8kMMFUjXNQUcBsrjdHcVSrc9ZdtpRGQQMAigatWqfgjNGANAzJ8w/T7YvRoube8kigsvcjsqk4uymmexLfVDYLiIHAcOAaWAksBO4Ek/xKEZhZDFdiEDqjoOGAcQFhaW0TGNMTmReAp+fBOWjIKgEtDzI7i8F0iGf4KmAMvqyuIIMCSL7QK86YcYYoCr0rWFeNoP4IyQCslgmzEmkHavcQr/xayH+r2g4ytObSdzTsoqWQxS1VVZPdnT7XO2VgF9Ux0zFDgfWKOq8SKyDqgNrPTsUtfzHGNMIJw6AYtehGXvQPGKcOMXULuj21EZl2V6Zyq7ROHxsB9i+A4oIiLhnse3AVM9I6HAGUY7UBxlcOZ6fOSH8xpj0tu+FN5v7lSIbXgz3LvcEoUBfJ9nsS2TTRV9PZGIXI2ziFID4HER6aaqPT1XD9cB74pIEs49kYGpnvoBUAPnyqIQ8Iiq/ubreY0xPjh5BOYPhzWfQKmL4ZaZcHGr7J9nzhm+joZKf/8iBGd+xBZfT6Sqa3BmYWe0bS3QNJNtCjzi63mMMTm0aS7Megj+2QdN74PIp6DY+W5HZfIYX5NFD1Xdka5tuohMA17zb0jGmFxx/AB89xj88TWUrws3fAZVrnY7KpNH+VobakfqxyJSFKgP1AtATMaYQFKFP76B7x511p2IeBJaPARFirkdmcnDfL1nkczpcx1OAI/5PSJjTOAc2Q2zh8Jfc+Giq6HbWKhQ1+2oTD7gazfUClINbwVOATGqmuT/kIwxfpecDL98CvOHQVICtH8RmtwNhQq7HZnJJ3xNFver6s6sdhCRMFVd7YeYjDH+FLcVZj4IO5ZC9ZZO4b/Sl7gdlclnfE0W40TkQTIps+ExGmh41hEZY/wjKRGWvwtRI6FwMeg6xpk7YaU6zBnwNVmUAqKA4ziLE5UGgoHd/JdAKvg9OmPMmdm/3in8t+cXqN0JOr8OJSu7HZXJx3xNFp8BK1V1ZkqDiHQD6qjqK57HXwYgPmNMTiTGw9LXna/gEOg1Hur1tKsJc9Z8LUTfInWiAFDVGUD7VI/7+DMwY0wORa+GD8Jh8StQ/3q4d6XzryUK4we+XlmUFpHGqppSzA8RaYqz3oQxxk2njsPCkc79iZKVod9XUOtat6MyBYyvyeJx4AcR2YdTNrwczgJEdjVhjJu2LYIZD8DhnRB2O7R9FoJLuh2VKYB8ncH9nYhUx6n4WgnYC8xW1bgAxmaMycy/h2H+M/DLRChdAwbOgerN3Y7KFGC+XlngSQwTReRaVf0+gDEZY7KycTbMGgrHY6D5gxDxBBQ9z+2oTAHnc7JI5XHAkoUxuSjm6Eme/CyKsaWmELxpOlSoDzdOgYtsapPJHWeSLGxohTG5SZXFX49l1P43KRIbD62fhuZDoHBRtyMz5xBfh86mNtfvURhjMhT+9CQWDoug967n2a4V6XByJNXn1KX28AVuh2bOMTm6shCRCsB3IiJAISskaEyAJCfDmvFEnTeMhMQkRibdwsen2lGsaBG616vIU53ruB2hOcf4dGUhIhVFZD7OKKhpwIXAGhFpFMjgjDknHdgCEzrD7P9RKLQRb9eeyEcJ7SlapAjxicmUCCpC+RLBbkdpzjG+dkN9AEwFygC7VPUwcC3wUoDiMubck5QIP46G95tDzHro/g4M+JbNCWW4qUk1pt3TnJuaVCP2n3i3IzXnIF+7oUqq6nsAIqIAqhojImdyz8MYk96+dTD9Xtj7G1zWxSn8V6IiAB8MCPPu9sJ19d2K0JzjfE0WQSJSU1W3pDSISFXA1mE05mwkxsOSUfDjm3BeKej9KdTtbvWcTJ7ja7IYAfwiIquAOiIyE2gC9AtYZMYUdLtWwIz74MBfcGU/aD8Szi/tdlTGZMjXch/zRORK4EZgE/A3zup5OwIYmzEFU/w/sPB5WPEBXFgF+n8DNdu6HZUxWcpJuY/twIup20Skr6p+4feojCmoti50ljg9vAsaD4I2wyCohNtRGZMtn5KFiBQDegAXk/Y+xUDAL8lCROoA7wJFgQuAL1ItrNQAeA9Ixlmpb6AVMTT5yr+HYN7T8OtnUOZSuHUuVGvqdlTG+MzXK4tpQFXgD+BkqnZ/Dvb+FJivqk+JSBlgs4j8BiwEpuMkiCgRGQG8D/T247mNCZwNM2DOw3D8ALQYCuGPQVGbJ2HyF1+TRUXgClXV1I0icqcfY6kHPAdOhVsR2QxcBQQBSaoa5dnvI2CHiJRT1Vg/nt8Y/zq230kSf86AipfDTV9BpSvdjsqYM+LrPIlVQEYdq/6cZzEb6AogIpfgJI8VQCNgY8pOqvo3cAKwcpsmb1KFXyfDO43hr3nOfYk7oyxRmHzN1yuLC4H1IrICOJqqvQPO7G5/uB2YISJbgdLAUFVdKCI3AkfS7XsYZ6W+NERkEDAIoGrVqn4Ky5gcOLwLZg6BrT9A6DXQ7W0oV8vtqIw5a74mi2twun/S82fdganAMlWNFJFQYL6IrPZs0wz2P23WkqqOA8YBhIWFZfQcYwIjORlWfQQLnnUedxwFje6AQlbkwBQMviaLF1X1w/SNIvKXP4LwjIRqC9wETleTp3DhI8A2nHsXqYUAMf44tzFnLfYvmHE//L0carSBrqMhxK5sTcHi66S8Dz11oJoBVXAm5S1T1Sl+iiNlOG5CqrYEoCTO/ZK+KY2eq47zgTV+OrcxZyYpAX56Cxa/AkXPh+vegytvtFIdpkDytUR5TWA9znKqrwPzgT9EpIaf4tgI7MaZIY6IlAC64Qyb/Q4oIiLhnn1vA6baSCjjqr2/wYeRzkzs2h3h3pXQoJ8lClNg+doN9TbwAjBFVZM9Vxl9gbFAx7MNQlXjReQ64A3PDe3iOHM73lLVRM+2d0UkCTiEMxnQmNyXcNK5kvjpLbigLPSZBHW7uR2VMQHna7I4T1U/T3mgqsnAZM/oI79Q1dVAq0y2rQVsuqtx185lTuG/uC3QoD+0f8GpFGvMOcDXZFFURGqo6taUBs9ciBwty2pMvhR/DBaMgFUfOjeuB0yDGq3djsqYXOXrm/3zwK+eeRaxQDkgDOgVqMCMyRM2L4BZQ+BINDS5G1o/A0HF3Y7KmFzn62iouZ4S5X1xRkP9DtxhJcpNgXXiIMx7En6bAmVrwW3zoGoTt6MyxjU5KVG+jXQlyo0pcFRhw3SnptO/h6DVI9DyYSv8Z855ds/BmBTH9sHs/8HGWVCpgXNvouLlbkdlTJ5gycIYVfj1c6fbKTEe2o6ApvdBYfvzMCZFpn8NnmGxh1T1q1yMx5jcdWiHs3LdtkVQtZlT+K9sTbejMibPyWoG92CcGduIyMiMdhCRNoEIypiAS06C5e/Du00hejV0fh0GzrZEYUwmsrrOFpyV8I6Q+YS4p4Af/B2UMQEVs9Ep/Be9Emq2gy5vQkio21EZk6dllSw+Bv4WkcIAnlIbqQkZlw43Jm9KSoAfR8OSV6FYcegxDq7oY/WcjPFBpslCVd8WkXE4S6p+QarKrx4C+KvqrDGBtWctTL8P9v8B9XpCx1eheDm3ozIm38hyuIeqxgM7RaSPZznTNESkT8AiM8YfEv6FRS/Bz2/DBeWh72S4rLPbURmT7/hUotyzGFFzEflIROZ6/m2WUQIxxi0xR0/S54NlxBw76TTs+Anea+5UiL2qP9y7whKFMWfI1/Usbga+ApJxFh1KBr4Skf4BjM2YHBnzw2ZW7TjIB/N+hVlDYUInSE6Em6c7Q2LPC3E7RGPyLV9nHd0NXK6qcSkNIlIGmAl8FojAjPFV7ae/Iz4xGYCIQmu5bd14kjnIp9qJW+/5CIpd4HKExuR/vq4mn5A6UQB4Hidksr8xuWbpo5HcWP983ir2LhOKjeIE5zG6+lg6P/KJJQpj/MTXK4tYERkGjOe/EuUDgZgAxWWMb1Qpv2s2T+0YSpAc4+3k6xmb0I3eITUoX8KK/xnjL74mi3uAz4Fn+W9uxXxgQABiMsY3R/fC7KGwaQ4Hgmozs8YY2oRHsn/lLmJTbnIbY/xCVH2fVycilXHWs/hbVfcGLCo/CAsL09WrV7sdhgkEVfhlInz/DCTFQ+unoclgK/xnjB+IyBpVDUvfnqO/LlXdA+zxW1TG5NTB7TDzAdi+BKq1gG5joEwNt6MypsCzj2Imf0hOghXvww/PQ6Ei0GU0NLwFCvk6RsMYczYsWZi8L+ZPp1TH7tVQqwN0fgMuvMjtqIw5p/iULESkFXBUVX8NbDjGpJJ4Cn58E5aMguCScP3HUP96K/xnjAt8vbKYCQwCfg1cKMaksnuNczURswEu7w0dXoYLyrodlTHnLF87fJeq6v+lbxSRCH8GIyJ3iMhPIvKjiPwuIuGe9gYissyzbaZn9rgpiE6dgHlPwUdt4d/DcOMXcP1HliiMcZmvVxZzROQpYAbOYkgpXgSa+SMQEekNtAFaqWqSiNwKVBSRYsB0YKCqRonICOB9oLc/zmvykO1LnUWJDm2Hq2+FdiMg+EK3ozLG4HuyGOv59/l07f5c/GgY0EdVkwBU9RMAEekOJKlqlGe/j4AdIlJOVWP9eH7jlpNHYP4wWDMBSl0Mt8yEi1u5HZUxJhVfu6EWq2qh9F/AAn8EISLlgTpAAxGJEpGlInKXZ3MjYGPKvp6y6CeAhv44t3HZprnwzjXOJLtm98Pgny1RGJMH+XplcW1Gjara3k9xVMdZea8H0BYoD6wUkSNABdJ2fQEc9uyThogMwrkRT9WqVf0UmgmI4wfgu8fgj6+hfD3o+xlcdLXbURljMuHr4kcJItJPRL4TkXkiUkpERomIvyq1BXlieVtVkzylRCYBt6WEkMFzThs/qarjVDVMVcPKlbMlM/MkVVj3NbzTGDZMh4gnYdAiSxTG5HG+Ln40DLgXmAeUUtVDwAbgAz/Fccjz7/5UbdE4dahigJB0+4dgFW/znyO7YUpf+OZ2597E3Ush4jEoUsztyIwx2fC1G6ot/41S6g7ODWg/rpS3Gec+RHngL09bOZw6VKuAvik7ikgocD7Oin0mP0hOhl8mwPfDnJXr2r8ITe6GQoXdjswY4yNfb3AXThmlhKdLSEQK4bxpnzVVjQcmArd7jn0BcAPwKfAdUCRlzgVO19RUGwmVT8RthYndYNZDcNFVcM8yaHqvJQpj8hlfryx+EpEFOG/epUTkeqAfEJX103LkYeB9EVkDJAITgM9UVUXkOuBdEUnC6bIa6MfzmkBISoTl70LUSCgc5KyBfdUAK9VhTD7l03oWIlIEeAy4Bc96Fjhv5qNUNTGQAZ4pW8/CRfvXO6U69vwCtTtD59ehZCW3ozLG+OCs1rPwJISRni9jMpYYD0tfd76CQ6DXJ1Cvh11NGFMA+FyiXETa4txorgTsBaao6g+BCszkM3+vghn3QexGuOIGp/Df+aXdjsoY4ye+Dp19DOcGNMAfOHMcPhORRwMVmMknTh2HuU/Cx+0g/hj0+wp6jrNEYUwB4+uVRX+gnmd+BQCeyq+LgVcDEZjJB7YtghkPwOGdEHY7tH3WWXfCGFPg+JosolMnCgBVjRORvQGIyeR1/x6G+c849ZxK14CBc6B6c7ejMsYEUKbJQkRSF1eaIyIvAF/hDF0tjXP/wu5ZnGs2zoZZQ+F4LDQfAhGPQ9Hz3I7KGBNgWV1Z7MCZgJd6KMuT6fZR4GU/x2Tyon9i4LtHYf00qHA59PsCKl/ldlTGmFySVbJYrKqRWT1ZRPw5Kc/kRarw+5cw9zHnZnbrp50risJF3Y7MGJOLskoWGZYlT8fmXRRkh/92ynRsmQ9VGkP3sVCutttRGWNckGmyUNWE1I9FpDFwCZC6ROjjQN3AhGZck5wMa8bD/OGgydDhFWh8p9VzMuYc5tNoKBGZAHTEqQiburxHxQDEZNx0YIuzDvaun+GSSOg6GkpVdzsqY4zLfB06exUQqqqnUjeKyDP+D8m4IikRlr0NUS9B0WDo/i406GelOowxgO/J4mec7qdT6dptAaKCYN86mH4v7P0NLuviFP4rYReNxpj/+JosXgYWishO4Fiq9g74b7U8k9sSTsKSUfDTaDivFPT+FOpd53ZUxpg8yNdk8X/AbmAjae9ZxPs9IpM7dq1wCv8d+Auu7AftR1o9J2NMpnxNFomq2iN9o4j84ud4TIDFHohj1fiH6HhiBnJhFej/DdRs63ZYxpg8ztdlVb8VkUYZtHfyZzAmwLb8QJEPmtHh+AyWl+npLHFqicIY4wNfV8rbjrOOxTH+u2chQAVV9cs63P5mK+Wl8u8hvnnpFq4vtJityZV4LOFOVutlAAQVKcSmFzq6HKAxJq84q5XygMOcvu61AG+eXVgm4DbMgDkP07PwAb4vfRMPx7TnqBYhuGgh2teryFOd67gdoTEmH/A1WQxS1VXpG0Wkn5/jMf5ybD/MeRj+nAEVL0du+orFywtxbM8ugooUIj4xmRJBRShfItjtSI0x+YCva3Cflig87gYe9F845qypwm9TYO4TkPAvtBkGzR6AwkU58M9qbmpSjX6NqzJ55S5ij510O1pjTD7h6z2LhZlsaqCqeXK85Tl5z+LQTpg1BLYuhNBroNvbUK6W21EZY/KRs71nUYm061aEAO2Bt88+NHPWkpNh1YewYIRTnqPTa84yp4V8HexmjDFZ8zVZ3Kqqy1M3iMjbwBf+D8nkSOxfTuG/v5dDjTZO4b+Qqtk+zRhjcsKnj57pE4VHaeAKfwYjIpeKSIKIRKRqaysiq0RkuYh8KiJ2RxYgKQGWvAbvN4fYjXDd+84EO0sUxpgA8LVE+bZ0TUFAWeB1P8fzHKmKFYpIOZyrl2aq+peIfAo8Dzzi5/PmL3t/cwr/7VsHdbs73U7Fy7sdlTGmAPO1G+oIMCTV41PATlXd469APDPE/wFiUzX3A35X1b88jz8CZojI46qa5K9z5xsJ/8LiV+CnMXBBWbjhM6jT1e2ojDHnAF+TRT9V/TOgkcAIYBDQLlVbI5zihSk24NxcrwlsCnA8ecvOZU7hv7gtcFV/uPYFp1KsMcbkgkzvWYjItJT/BzpRiEhHYL2qRqfbVAHnqibFYc+/Gfa5iMggEVktIqtjY2Mz2iX/iT8Gsx+GTzpA0ikY8C10f8cShTEmV2V1ZRHhmV8hQMpkjJRl01Ieq6q2OZsARKQQ8BjQM5NdMpoIkuHybao6DhgHzjyLs4krT9i8wJk3cSQamgyG1k9DUHG3ozLGnIOySha/qmrr9I0iUgP4GKiDM4P7bPUD5qnqwQy2xeB0O6UISdVecJ04CPOedGZil60Nt38PoY3djsoYcw7LKlncnL5BRB7CGY00G+ilqgf8EENLoL6ItPc8rgiM9qzKFwWkvoNbF6craosfzpv3qMKGb2HOI/DvIWj1KLR6GIoEuR2ZMeYcl2myUNW/U/4vIpcBnwA1gNtU9Ut/BaCqd6V+LCI7gCGqukhEygNPi8ilqroZuA34SFUTMzhU/nZsH8z+H2ycBZUawIBpUPFyt6Myxhggm0l5IlJIRJ4E1gJ7gfr+TBTpztVYRBbx35XFMFWNAfoCk0VkOVAYeCYQ53eNKvwyCcY2hi0LoN1zcMcPliiMMXlKplcWInIFMB6ojnM1MSWDfZ5W1Rf8EYiqrgQiMmhfACzwxznynEM7YOaDsG0RVGsOXcdA2ZpuR2WMMafJ6p7FapxRRx8Dl4rIsHTbBbgF8EuyOKckJ8HKcfDDcyCFofMbcPWtVvjPGJNnZZUs1pN21nZGrvNbJOeKmI3O5LroVVCznVP478IqbkdljDFZyipZjFDVxVk9WURG+DmegivxFPw0GpaMgmLFoeeHcHlvp6S4McbkcVmNhvo2uyf7so8Bdv/ilBHf/wfU6wkdX4Xi5dyOyhhjfOZrbShzJhL+hagXYdlYKF4B+k6Byzq5HZUxxuSYJYtA2fGjczVxcBs0vMUZEnteiNtRGWPMGbFk4W8nj8KC4bB6PJSqDjfPgEvC3Y7KGGPOiiULf/prHsx6CI7thab3QeSTUOwCt6MyxpizZsnCH47HwdzHYd2XUK4O9JkIVcLcjsoYY/zGksXZUIU/voHvHnW6n8Ifh5b/gyLF3I7MGGP8ypLFmTq6xyn8t2kOVG4I3cdChXpuR2WMMQFhySKnVOGXT+H7ZyApwVne9Jp7oFBhtyMzxpiAsWSREwe3wYwHYMdSqN4Sur4FZWq4HZUxxgScJQtfJCfB8vdg4QtQuCh0Ge3MnbDCf8aYc4S926UTc/QkfT5YRsyxk07D/g3wcTv4/ilnvsQ9yyHMKsQaY84tdmWRzpgfNrNqx0He+X4DI8p8D0teg+CScP3HUP96K/xnjDknWbLwqP30d8QnJgNwpWzhxt8eg0J/MzO5OV3vnQQXlHE5QmOMcY/1pXgsfTSSbg0qM6TYt0wtNpwQOc64Ki/S5JGpliiMMec8SxYe5UsGUyKoCNuSyvOVtuHaU6+yq0wrypcIdjs0Y4xxnXVDpXLgn3jKNbqRKxpXpdvKXcSm3OQ2xphznKiq2zEERFhYmK5evdrtMIwxJl8RkTWqelpxO+uGMsYYky1LFsYYY7JlycIYY0y2LFkYY4zJliULY4wx2bJkYYwxJluWLIwxxmSrwM6zEJFYYKfbcfioLHDA7SACpCC/NijYr89eW/51Nq+vmqqWS99YYJNFfiIiqzOaBFMQFOTXBgX79dlry78C8fqsG8oYY0y2LFkYY4zJliWLvGGc2wEEUEF+bVCwX5+9tvzL76/P7lkYY4zJll1ZGGOMyZYlC2OMMdmyZOESESkqIkNEZJGILBaRZSLSxu24/E1ELhWRBBGJcDsWfxKRO0TkJxH5UUR+F5Fwt2PyFxGpIyJRnte2VkQeczumsyEijURki4gMTNfewPN395OIzBSRfLd+ckavTUSqi8h4EVkoIstFZIqInDZvIqcsWbjnIuBBoLuqhgPDgOkicpG7Yfndc8Apt4PwJxHpDbQBWqlqC+BNoKK7UfnVp8DPntfWFnhMRDq4HNMZEZEewEPAkXTtxYDpwJOq2hz4BXg/9yM8c5m9NmAgcFhVWwNNgST8cMPbkoV7jgHDVPUIgKrOB04CzVyNyo9EpBHwDxDrdix+Ngx4TlWTAFT1E1X9P5dj8qd6wDIAVY0DNgNXuRrRmVulqv1w/t5S6wgkqWqU5/FHQE9/fALPRZm9tl+AdwDUGcH0BdDubE9mycIlqhqnqpNSHouIAMUoWG+sIzxfBYaIlAfqAA08XTVLReQut+Pys9lAVwARuQQneaxwNaIzpKrRmWxqBGxMtd/fwAmgYW7E5Q+ZvTZVnaGqW1M1BeOH0iZFzvYAxm/CcWpZLXE7EH8QkY7AelWNdvJggVEdEKAHThdNeWCliBxR1S/cDMyPbgdmiMhWoDQwVFUXuhyTv1Xg9O6bwzg/z4KmC54rjbNhVxZ5gIgEAy8CA1U12e14zpaIFAIeA15yO5YACML5u3lbVZNUdS8wCbjN3bD8aiqwTFVrAFcAQ0Uk33zizoGMJpkVqE82ItIMqAGMPttjWbJwmaf7aRzwpqqucTseP+kHzFPVg24HEgCHPP/uT9UWDVRxIRa/E5E6OFdMo8HbPTMfeMTFsAIhBghJ1xbiaS8QRKQa8DLQS1UTzvZ4lizc9zqwUlW/EpEgEanqdkB+0BLo4hkWvAhnpNBoEZnublh+sRmnbzt1d0U5YI874fhdMc+/qd9cEoCSLsQSSKuA2ikPRCQUOB8oEB/YRKQszhXvQFXdLyJVRSTobI5pycJFnvHrRYAJIlIc53Ix33dnqOpdqtpcVSNUNQLYBwxR1e4uh3bWVDUemIjTr4+IXADcgDPctCDYCOwGbgQQkRJAN6Cg3bP4DiiSan7MbcBUVc33A0w87yXf4Izai/E8vhuodFbHtdpQ7hCRWsCmDDaNUNVnczmcgBCRxsCrwDU4b0JTVfU5d6M6e54E8T5QF0jE+cMcpQXkj0lEwoA3cPrviwMLgCdUNdHVwM6AiFyNc/XeAOdDywZV7enZdhXwLs48hEM4n8LjXAo1xzJ7bSIyEngyg6dcrKo7zvh8BeT32xhjTABZN5QxxphsWbIwxhiTLUsWxhhjsmXJwhhjTLYsWRhjjMmWJQtjjDHZsmRhjAtE5G0ROZx+QR5j8ipLFsa4QFXvB351Ow5jfGXJwhhjTLZsPQtjcomnjMb7OCsirqKAlcM2BZtdWRiTCzxrPk8DXvesbf0p0MTdqIzxnSULY3JHU5yy5l8CqOqvwF9uBmRMTliyMCZ3VAIOq2pSqraCuDiUKaAsWRiTO/YCISKS+j5hGbeCMSanLFkYkzuW4SzZeQOAiDQA6rgZkDE5YetZGJNLRKQR/42GWo+zeFJZ4FFVneFmbMZkx5KFMcaYbFk3lDHGmGxZsjDGGJMtSxbGGGOyZcnCGGNMtixZGGOMyZYlC2OMMdmyZGGMMSZbliyMMcZk6/8BZGQpyE3OAgYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/javascript": [
+       "\n",
+       "            setTimeout(function() {\n",
+       "                var nbb_cell_id = 12;\n",
+       "                var nbb_unformatted_code = \"count_gates(\\\"mirror\\\", num_trials=10, seed=0)\";\n",
+       "                var nbb_formatted_code = \"count_gates(\\\"mirror\\\", num_trials=10, seed=0)\";\n",
+       "                var nbb_cells = Jupyter.notebook.get_cells();\n",
+       "                for (var i = 0; i < nbb_cells.length; ++i) {\n",
+       "                    if (nbb_cells[i].input_prompt_number == nbb_cell_id) {\n",
+       "                        if (nbb_cells[i].get_text() == nbb_unformatted_code) {\n",
+       "                             nbb_cells[i].set_text(nbb_formatted_code);\n",
+       "                        }\n",
+       "                        break;\n",
+       "                    }\n",
+       "                }\n",
+       "            }, 500);\n",
+       "            "
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "count_gates(\"mirror\", num_trials=10, seed=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3251808d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "0adcc2737ebf6a4a119f135174df96668767fca1ef1112612db5ecadf2b6d608"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
As you know, the depth in our paper is a quite abstract parameter and it would be nice inform the reader about the actual  number of two-qubit gates (and maybe single-qubit gates) that are in our benchmark circuits.

This notebook solves this issue.

I'll put, in some way, some of the results generated by this notebook on the overleaf draft.

cc @nathanshammah 